### PR TITLE
Document ROS2 interfaces and fix bumper contact handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ The best solution for each module surfaces for over time, with the project maste
 
 1. Pick a contribution from the [list below](#requests-for-contributions).
 2. [Let us know](https://github.com/makerspet/oomwoo/discussions) you're working on it and your progress.
-3. Check [ARCHITECTURE.md](docs/ARCHITECTURE.md) for the system design and interfaces.
+3. Check [ARCHITECTURE.md](docs/ARCHITECTURE.md) and
+   [SOFTWARE_INTERFACES.md](docs/SOFTWARE_INTERFACES.md) for the system design
+   and ROS2 interfaces.
 
 Follow us building in public:
 

--- a/contributions/clean-and-map/README.md
+++ b/contributions/clean-and-map/README.md
@@ -23,6 +23,7 @@ physical robot isn't built yet, this is a *Gazebo simulation*.
 
 # Important References
 - [urdf-gazebo-sim RFC](../urdf-gazebo-sim) — provides the robot URDF, the Gazebo world(s), and the *bumper* this package depends on.
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract for simulation-first modules.
 - [m-explore-ros2 (kaiaai fork)](https://github.com/kaiaai/m-explore-ros2) — frontier exploration, tested and working. It maps and explores but does *not* clean — a good starting point to build on.
 - [m-explore-ros2 demo + step-by-step instructions (video)](https://www.youtube.com/watch?v=81-9q7QfkHs&list=PLOSXKDW70aR8uA1IFahSKVuk5ODDfjTZV) — shows m-explore-ros2 in action and how to run it.
 - [Gazebo simulation setup instructions](https://makerspet.com/blog/tutorial-map-navigate-ros2-robot-in-simulation/) — a simple differential-drive robot with a LiDAR in a Gazebo living room world; another possible starting point.

--- a/contributions/cleaning-jobs/README.md
+++ b/contributions/cleaning-jobs/README.md
@@ -17,6 +17,7 @@ the [live-robot-bringup RFC](../live-robot-bringup).
 - [clean-and-map RFC](../clean-and-map) — coverage cleaning and its done condition; this orchestrates and segments it.
 - [nav-localize RFC](../nav-localize) — the saved map this segments and the resume-after-interruption support.
 - [dock-cycle RFC](../dock-cycle) — the recharge / auto-empty / mop-wash station services a job pauses for.
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract for simulation-first modules.
 - [OOMWOO ROS2 development](https://github.com/makerspet/oomwoo-install) — build OOMWOO ROS2 Docker image(s) with your packages.
 - Nav2 keepout/zone costmap filters are a good starting point for no-go zones.
 - [Project discussions](https://github.com/makerspet/oomwoo/discussions?discussions_q=)

--- a/contributions/dock-cycle/README.md
+++ b/contributions/dock-cycle/README.md
@@ -17,6 +17,7 @@ hardware in the [live-robot-bringup RFC](../live-robot-bringup).
 - [nav-localize RFC](../nav-localize) — localization + Nav2; the find-the-dock fallback is invoked when its relocalization fails.
 - [clean-and-map RFC](../clean-and-map) and [cleaning-jobs RFC](../cleaning-jobs) — trigger return-to-dock for recharge / auto-empty / mop-wash mid-job.
 - [urdf-gazebo-sim RFC](../urdf-gazebo-sim) — robot URDF and Gazebo world(s) to model the dock in.
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract for simulation-first modules.
 - Model a *generic basic charging dock* (charge contacts + a detectable marker). Exact dock geometry is TBD — the old teardown reference vacuum is no longer used.
 - [OOMWOO ROS2 development](https://github.com/makerspet/oomwoo-install) — build OOMWOO ROS2 Docker image(s) with your packages.
 - Nav2 docking (`opennav_docking`) is a good starting point for precise approach.

--- a/contributions/floor-care/README.md
+++ b/contributions/floor-care/README.md
@@ -15,6 +15,7 @@ hardware in the [live-robot-bringup RFC](../live-robot-bringup).
 # Important References
 - [clean-and-map RFC](../clean-and-map) — coverage cleaning that this refines at edges and surface transitions.
 - [urdf-gazebo-sim RFC](../urdf-gazebo-sim) — robot URDF; this package likely needs a *surface sensor* and a *mop lift/lower actuator* modeled.
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract for simulation-first modules.
 - [OOMWOO ROS2 development](https://github.com/makerspet/oomwoo-install) — build OOMWOO ROS2 Docker image(s) with your packages.
 - [Project discussions](https://github.com/makerspet/oomwoo/discussions?discussions_q=)
 - [Discord server](https://discord.gg/3y2JKz5T25)

--- a/contributions/live-robot-bringup/README.md
+++ b/contributions/live-robot-bringup/README.md
@@ -23,6 +23,7 @@ cost is paid once.
 - [remakeai/vacuum_ros2_bridge](https://github.com/remakeai/vacuum_ros2_bridge) — ROS2 bridge for a 3irobotix CRL-200-based vacuum (Proscenic), full ROS2 control.
 - [codetiger/VacuumTiger](https://github.com/codetiger/VacuumTiger) — 3irobotix CRL-200-based low-level control, reverse engineered.
 - The behavior RFCs whose tests you re-run on hardware: [clean-and-map](../clean-and-map), [nav-localize](../nav-localize), [dock-cycle](../dock-cycle), [recovery-safety](../recovery-safety), [floor-care](../floor-care), [cleaning-jobs](../cleaning-jobs).
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract that hardware bring-up should validate.
 - [OOMWOO ROS2 development](https://github.com/makerspet/oomwoo-install) — build OOMWOO ROS2 Docker image(s) with your packages.
 - [Project discussions](https://github.com/makerspet/oomwoo/discussions?discussions_q=)
 - [Discord server](https://discord.gg/3y2JKz5T25)

--- a/contributions/nav-localize/README.md
+++ b/contributions/nav-localize/README.md
@@ -15,6 +15,7 @@ the [live-robot-bringup RFC](../live-robot-bringup).
 # Important References
 - [clean-and-map RFC](../clean-and-map) — produces the saved/partial map this package consumes.
 - [urdf-gazebo-sim RFC](../urdf-gazebo-sim) — robot URDF, Gazebo world(s), bumper.
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract for simulation-first modules.
 - [Gazebo + Nav2 simulation tutorial](https://makerspet.com/blog/tutorial-map-navigate-ros2-robot-in-simulation/) — baseline diff-drive + LiDAR robot in a Gazebo world.
 - [OOMWOO ROS2 development](https://github.com/makerspet/oomwoo-install) — build OOMWOO ROS2 Docker image(s) with your packages.
 - Nav2 (navigation), AMCL (localization), and slam_toolbox (localization mode / serialized session continue) are the expected building blocks.

--- a/contributions/recovery-safety/README.md
+++ b/contributions/recovery-safety/README.md
@@ -17,6 +17,7 @@ simulation*; it is later re-validated on hardware in the
 # Important References
 - [clean-and-map RFC](../clean-and-map) and [urdf-gazebo-sim RFC](../urdf-gazebo-sim) — the *bumper* (left / right / front) and any cliff / wheel-drop sensors this package reacts to.
 - [nav-localize RFC](../nav-localize) — pickup / kidnap detection ties into relocalization.
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract for simulation-first modules.
 - [OOMWOO ROS2 development](https://github.com/makerspet/oomwoo-install) — build OOMWOO ROS2 Docker image(s) with your packages.
 - Nav2's behavior/recovery server is a good starting point for composing recoveries.
 - [Project discussions](https://github.com/makerspet/oomwoo/discussions?discussions_q=)

--- a/contributions/urdf-gazebo-sim/README.md
+++ b/contributions/urdf-gazebo-sim/README.md
@@ -12,6 +12,7 @@ software modules (mapping, navigation, cleaning) can be developed *without hardw
 # Important References
 - [Simulate the Proscenic M6 Pro in Gazebo with ROS2](https://makerspet.com/blog/simulate-the-proscenic-m6-pro-robot-vacuum-in-gazebo-with-ros-2/) — the tested sim this forks from, and the template for the new OOMWOO write-up.
 - [makerspet/oomwoo_urdf](https://github.com/makerspet/oomwoo_urdf) — OOMWOO URDF package + config.
+- [ROS2 software interfaces](../../docs/SOFTWARE_INTERFACES.md) — shared topic/action/service contract this simulation should provide.
 - [makerspet/oomwoo-install](https://github.com/makerspet/oomwoo-install) — builds the OOMWOO ROS2 Docker image(s).
 - [Project discussions](https://github.com/makerspet/oomwoo/discussions?discussions_q=) · [Discord](https://discord.gg/3y2JKz5T25)
 

--- a/contributions/urdf-gazebo-sim/alvarosamudio/oomwoo_gazebo/README.md
+++ b/contributions/urdf-gazebo-sim/alvarosamudio/oomwoo_gazebo/README.md
@@ -154,7 +154,7 @@ gz sim -s -r --headless-rendering <world.sdf>
 | SDF `box size="..."` attribute syntax deprecated | Changed to nested `<box><size>...</size></box>` in all worlds |
 | `fuel.gazebosim.org` remote model references | Replaced with self-contained light + ground_plane models |
 | GPU LiDAR requires hardware GPU | Switched to `type="lidar"` (CpuLidar) with physics raycasting |
-| Bumper bridge `Contact` → `Contacts` type mismatch | Fixed ROS msg type in `gz_bridge.yaml` |
+| Bumper bridge `Contact` → `Contacts` type mismatch | Fixed ROS msg type in `gz_bridge.yaml` and `bump_recovery.py` |
 | SDF 1.8 gravity deprecation warning | Moved `gravity` to `<world>` level in all SDFs |
 
 ## Dependencies

--- a/contributions/urdf-gazebo-sim/alvarosamudio/oomwoo_gazebo/oomwoo_gazebo/bump_recovery.py
+++ b/contributions/urdf-gazebo-sim/alvarosamudio/oomwoo_gazebo/oomwoo_gazebo/bump_recovery.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import rclpy
 from rclpy.node import Node
-from ros_gz_interfaces.msg import Contact
+from ros_gz_interfaces.msg import Contacts
 from geometry_msgs.msg import Twist
 
 
@@ -10,32 +10,42 @@ class BumpRecovery(Node):
         super().__init__("bump_recovery")
         self._cmd_pub = self.create_publisher(Twist, "cmd_vel", 10)
         self._left_sub = self.create_subscription(
-            Contact, "bumper_left", self._left_cb, 10
+            Contacts, "bumper_left", self._left_cb, 10
         )
         self._right_sub = self.create_subscription(
-            Contact, "bumper_right", self._right_cb, 10
+            Contacts, "bumper_right", self._right_cb, 10
         )
         self._recovering = False
         self._timer = None
 
     def _left_cb(self, msg):
-        if self._recovering or not msg.collisions:
+        if self._recovering or not msg.contacts:
             return
         if self._is_real_contact(msg):
             self._recover("left")
 
     def _right_cb(self, msg):
-        if self._recovering or not msg.collisions:
+        if self._recovering or not msg.contacts:
             return
         if self._is_real_contact(msg):
             self._recover("right")
 
     def _is_real_contact(self, msg):
-        for c in msg.collisions:
-            if (not c.collision1.name.startswith("ground_plane")
-                    and not c.collision2.name.startswith("ground_plane")):
+        for contact in msg.contacts:
+            if not self._is_ground_contact(contact):
                 return True
         return False
+
+    @staticmethod
+    def _is_ground_contact(contact):
+        return (
+            BumpRecovery._is_ground_entity(contact.collision1.name)
+            or BumpRecovery._is_ground_entity(contact.collision2.name)
+        )
+
+    @staticmethod
+    def _is_ground_entity(name):
+        return "ground_plane" in name.split("::")
 
     def _recover(self, side):
         self._recovering = True

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,12 +98,13 @@ Every hardware module's RFC must specify, against this standard:
 ## 6. Software architecture
 
 ### 6.1 ROS2 graph (MVP)
-- *TBD:* Node list and the topic/service/action interfaces between them.
 - Core nodes (MVP): LiDAR driver, base controller (diff-drive), odometry,
   teleop, SLAM (manual mapping), TF/URDF publisher.
 - *Interface contract:* each software module's RFC declares the ROS2 topics,
   services, message types, and parameters it publishes/consumes. Modules depend
-  on these interfaces, not on each other's code.
+  on these interfaces, not on each other's code. See
+  [SOFTWARE_INTERFACES.md](SOFTWARE_INTERFACES.md) for the current draft ROS2
+  graph contract.
 
 ### 6.2 Simulation
 - Gazebo + URDF, with a set of residential-layout worlds for navigation and

--- a/docs/SOFTWARE_INTERFACES.md
+++ b/docs/SOFTWARE_INTERFACES.md
@@ -1,0 +1,153 @@
+# OOMWOO ROS2 Software Interfaces
+
+> Status: DRAFT. This is the shared software contract for simulation-first
+> contributions. It reflects the current `urdf-gazebo-sim` package and should be
+> updated whenever a module needs a new public topic, service, action, frame, or
+> parameter.
+
+## Purpose
+
+OOMWOO software modules are meant to be swappable. A contributor should be able
+to build `clean-and-map`, `nav-localize`, `recovery-safety`, `dock-cycle`, or
+`cleaning-jobs` without depending on another module's private implementation.
+
+This document defines the public ROS2 surface area those modules can share while
+the hardware is still evolving. It is not a final hardware API.
+
+## Naming rules
+
+- Public names below are shown as root topics, for example `/scan`. Launch files
+  and node configs may use relative names such as `scan` when they resolve to
+  the same root topic in the default launch.
+- Use REP-103 frames and SI units.
+- Prefer standard ROS2/Nav2 message types before adding custom OOMWOO messages.
+- If a module introduces a new public interface, document the producer, consumer,
+  message type, QoS expectation, and failure behavior in its README and update
+  this file.
+- Simulation-only details, such as Gazebo collision entity names, must not leak
+  into cross-module contracts unless they are explicitly marked as simulation
+  diagnostics.
+
+## Frames
+
+| Frame | Owner | Meaning |
+|---|---|---|
+| `map` | SLAM/localization | Global map frame used by SLAM, AMCL, Nav2, and saved maps. |
+| `odom` | Base odometry | Locally continuous odometry frame. |
+| `base_footprint` | Robot description / odometry | Planar base frame for navigation. |
+| `base_link` | Robot description | Main robot body frame. Hardware modules should reference this once geometry is frozen. |
+| `base_scan` | Robot description | 2D LiDAR frame. |
+
+Open decision: `base_link` origin, reference plane, robot diameter, and height
+envelope are still defined in `ARCHITECTURE.md`.
+
+## Baseline Topics
+
+These topics are provided by the current Gazebo simulation or standard Nav2/SLAM
+bringup and should be treated as the MVP baseline.
+
+| Topic | Type | Direction | Producer | Consumers |
+|---|---|---|---|---|
+| `/cmd_vel` | `geometry_msgs/msg/Twist` | Command | Teleop, Nav2 velocity smoother, recovery nodes | Gazebo diff-drive / base controller |
+| `/odom` | `nav_msgs/msg/Odometry` | State | Gazebo odometry / base controller | SLAM, AMCL, Nav2, recovery and job logic |
+| `/tf` | `tf2_msgs/msg/TFMessage` | State | Robot state publisher, odometry, SLAM/localization | All pose-aware modules |
+| `/joint_states` | `sensor_msgs/msg/JointState` | State | Gazebo joint state publisher / hardware base | Robot state publisher, diagnostics |
+| `/scan` | `sensor_msgs/msg/LaserScan` | Sensor | 2D LiDAR / Gazebo LiDAR | SLAM, AMCL, Nav2 costmaps, wall following |
+| `/map` | `nav_msgs/msg/OccupancyGrid` | State | SLAM or map server | Nav2, cleaning, zones, visualization |
+| `/bumper_left` | `ros_gz_interfaces/msg/Contacts` in Gazebo | Sensor | Gazebo left contact sensor | Recovery, safety, clean-and-map obstacle handling |
+| `/bumper_right` | `ros_gz_interfaces/msg/Contacts` in Gazebo | Sensor | Gazebo right contact sensor | Recovery, safety, clean-and-map obstacle handling |
+
+### Bumper events
+
+The current simulation publishes raw Gazebo contact messages:
+
+- Message type: `ros_gz_interfaces/msg/Contacts`
+- Contact list field: `contacts`
+- Per-contact fields: `collision1`, `collision2`, `positions`, `normals`,
+  `depths`, `wrenches`
+
+Consumers should treat `len(msg.contacts) > 0` as a bumper event after filtering
+out ground-plane contacts. Do not read a `collisions` field; that belongs to the
+single-contact message type and is not what the bridge publishes.
+
+Hardware may eventually replace raw Gazebo contacts with a normalized bumper
+message. Until that decision is made, module submissions should isolate the
+Gazebo-specific parsing behind a small adapter.
+
+## Nav2 Interfaces
+
+Modules should reuse Nav2 actions and servers where possible.
+
+| Interface | Type | Typical consumer |
+|---|---|---|
+| `/navigate_to_pose` | `nav2_msgs/action/NavigateToPose` | `nav-localize`, `cleaning-jobs`, `dock-cycle` |
+| `/navigate_through_poses` | `nav2_msgs/action/NavigateThroughPoses` | Coverage, room jobs, dock approach |
+| Nav2 behavior server | `spin`, `backup`, `drive_on_heading`, `wait` behaviors | Recovery and local fallback logic |
+| Costmaps | Nav2 local/global costmap topics | Obstacle handling, zones, diagnostics |
+| Map saver | Nav2 map saver service/CLI | `clean-and-map`, `nav-localize` |
+
+If a module needs to command motion directly, it must define how it arbitrates
+with Nav2 and recovery nodes so two nodes do not fight over `/cmd_vel`.
+
+## Module Contracts
+
+| Module | Inputs | Outputs / public behavior |
+|---|---|---|
+| `urdf-gazebo-sim` | `/cmd_vel` | Publishes `/scan`, `/odom`, `/tf`, `/joint_states`, `/bumper_left`, `/bumper_right`; provides worlds and robot description. |
+| `clean-and-map` | `/scan`, `/odom`, `/tf`, bumper events, optional Nav2 actions | Drives first-pass coverage, produces a complete map, defines a done condition, saves map artifacts. |
+| `nav-localize` | Saved map, `/scan`, `/odom`, `/tf`, Nav2 bringup | Provides known-map navigation, relocalization, and map-resume behavior. |
+| `recovery-safety` | Bumper events, future cliff/wheel-drop/pickup/e-stop signals, Nav2 failures | Stops or gates motion, runs bounded recoveries, publishes clear pause/error status. |
+| `floor-care` | `/scan`, map/coverage context, future surface sensor | Provides wall/edge following, surface classification, and mop actuator decisions. |
+| `cleaning-jobs` | Saved map, zones, coverage progress, battery/bin/mop status, Nav2 actions | Provides start/pause/resume/cancel/status job behavior suitable for a future Home Assistant layer. |
+| `dock-cycle` | Nav2/localization, dock marker, battery/service state | Provides undock, return-to-dock, precise docking, recharge/service completion, and find-dock fallback. |
+| `live-robot-bringup` | Hardware drivers, same logical topics | Validates that hardware exposes the same public interfaces as the simulation. |
+
+## Status and Errors
+
+The final robot status API is still open. Until it is selected, modules that
+need status reporting should document:
+
+- `state`: short machine-readable state, for example `cleaning`, `recovering`,
+  `paused`, `docked`, or `error`
+- `reason_code`: stable machine-readable reason, for example `BUMPER_STUCK`,
+  `LOCALIZATION_LOST`, or `LOW_BATTERY`
+- `message`: human-readable explanation
+- `recoverable`: whether a resume command is expected to work
+- `source`: module name that produced the status
+
+Open decision: choose the transport and type for cross-module status, likely a
+standard diagnostic message or a small OOMWOO-specific message package.
+
+## QoS and Parameters
+
+- `use_sim_time` should be true in simulation launch files.
+- Sensor streams such as `/scan` should use sensor-data QoS where configurable.
+- `/map` and saved-map metadata should be available to late joiners where the
+  producer supports transient-local durability.
+- Command topics should use small queues and should fail safe: stale commands
+  must not keep the robot moving.
+
+## Validation Checklist
+
+A module submission that depends on the MVP simulation should document how to
+check the interfaces it uses. At minimum:
+
+```bash
+ros2 topic list
+ros2 topic echo /scan --once
+ros2 topic echo /odom --once
+ros2 topic echo /bumper_left
+ros2 topic echo /bumper_right
+ros2 run tf2_tools view_frames
+```
+
+For Nav2-based modules, also document how to send a `NavigateToPose` goal and
+how to confirm `/cmd_vel` arbitration is safe.
+
+## Open Decisions
+
+- Final hardware bumper/cliff/wheel-drop message shape.
+- Robot-wide status/error message type and topic.
+- Battery, dust-bin, mop, and dock service state interfaces.
+- Localization-confidence interface for relocalization and kidnap detection.
+- Job action/service API for start, pause, resume, cancel, and status.

--- a/docs/blog/oomwoo-one-simulate-in-gazebo.md
+++ b/docs/blog/oomwoo-one-simulate-in-gazebo.md
@@ -103,8 +103,8 @@ drives there on its own.
 ## 10. Check the bumper sensors
 
 ```
-ros2 topic echo /bumper_left/contact
-ros2 topic echo /bumper_right/contact
+ros2 topic echo /bumper_left
+ros2 topic echo /bumper_right
 ```
 Drive into a wall and watch the left/right contact events fire.
 


### PR DESCRIPTION
## Summary
- add a draft `docs/SOFTWARE_INTERFACES.md` contract for MVP ROS2 topics, frames, Nav2 actions, module boundaries, status/error conventions, QoS notes, and validation checks
- link the shared interface contract from the architecture, README, and active software RFCs so contributors can build against the same surface area
- subscribe the bumper recovery node to `ros_gz_interfaces/msg/Contacts`, matching `gz_bridge.yaml`, and read `msg.contacts` instead of the non-existent `msg.collisions`
- correct the bumper echo commands in the Gazebo tutorial draft

## Testing
- `python3 -m py_compile contributions/urdf-gazebo-sim/alvarosamudio/oomwoo_gazebo/oomwoo_gazebo/bump_recovery.py`
- `git diff --check origin/main`
- `rg -n "/bumper_(left|right)/contact|msg\.collisions|from ros_gz_interfaces.msg import Contact\b|SOFTWARE_INTERFACES" README.md docs contributions`