### PR TITLE
Add recovery safety prototype package

### DIFF
--- a/contributions/recovery-safety/xbattlax/README.md
+++ b/contributions/recovery-safety/xbattlax/README.md
@@ -1,0 +1,117 @@
+# Recovery Safety Prototype by xbattlax
+
+This contribution provides a first ROS2 recovery-and-safety package for the
+OOMWOO recovery-safety RFC. It is deliberately small, deterministic, and
+simulation-first:
+
+- a bounded recovery ladder for bumper, wedged, no-path, and lost-localization
+  situations
+- immediate safe stop for e-stop, cliff, wheel-drop, and pickup events
+- pause-and-alert when the ladder is exhausted
+- a structured JSON status topic suitable for later Home Assistant integration
+- unit tests for guaranteed termination and safety responses
+
+The core ladder lives in pure Python, so it can be regression-tested without a
+running ROS graph. The ROS2 node is a thin adapter around that core.
+
+## Package
+
+`oomwoo_recovery_safety`
+
+Location:
+
+```text
+contributions/recovery-safety/xbattlax/oomwoo_recovery_safety
+```
+
+## Interfaces
+
+### Subscribed topics
+
+| Topic | Type | Purpose |
+|---|---|---|
+| `/bumper_left` | `ros_gz_interfaces/msg/Contacts` | Trigger left-bumper recovery after filtering ground-plane contacts. |
+| `/bumper_right` | `ros_gz_interfaces/msg/Contacts` | Trigger right-bumper recovery after filtering ground-plane contacts. |
+| `/oomwoo/recovery/event` | `std_msgs/msg/String` | Manual/test trigger. Payload examples: `wedged`, `no_valid_path`, `localization_lost`, `bumper_front`. |
+| `/oomwoo/recovery/behavior_result` | `std_msgs/msg/String` | Optional external result for the current behavior: `succeeded`, `failed`, or JSON `{"outcome":"succeeded"}`. |
+| `/oomwoo/safety/e_stop` | `std_msgs/msg/Bool` | Immediate non-recoverable pause. |
+| `/oomwoo/safety/cliff` | `std_msgs/msg/Bool` | Immediate safety pause. |
+| `/oomwoo/safety/wheel_drop` | `std_msgs/msg/Bool` | Immediate safety pause. |
+| `/oomwoo/safety/pickup` | `std_msgs/msg/Bool` | Immediate safety pause for pickup/kidnap handoff. |
+| `/oomwoo/recovery/reset` | `std_msgs/msg/Bool` | Reset a paused/recovered controller when true. |
+
+### Published topics
+
+| Topic | Type | Purpose |
+|---|---|---|
+| `/cmd_vel` | `geometry_msgs/msg/Twist` | Short bounded motion commands for recovery. |
+| `/oomwoo/status` | `std_msgs/msg/String` | JSON status with `state`, `reason_code`, `message`, `recoverable`, `source`, and recovery metadata. |
+| `/oomwoo/recovery/command` | `std_msgs/msg/String` | JSON command for non-motion actions such as `clear_costmap`. |
+
+## Build
+
+From the OOMWOO ROS2 container:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+cd /workspace
+colcon build \
+  --base-paths contributions/recovery-safety/xbattlax/oomwoo_recovery_safety \
+  --packages-select oomwoo_recovery_safety
+```
+
+## Test
+
+```bash
+source /opt/ros/jazzy/setup.bash
+cd /workspace
+colcon test \
+  --base-paths contributions/recovery-safety/xbattlax/oomwoo_recovery_safety \
+  --packages-select oomwoo_recovery_safety
+colcon test-result --verbose
+```
+
+The tests cover:
+
+- bounded escalation to pause-and-alert
+- successful recovery stopping the ladder
+- e-stop and safety events entering safe pause
+- ignored duplicate triggers while already recovering
+- JSON status shape
+
+## Run
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 launch oomwoo_recovery_safety recovery_safety.launch.py
+```
+
+Manual trigger example:
+
+```bash
+ros2 topic pub --once /oomwoo/recovery/event std_msgs/msg/String "{data: bumper_front}"
+```
+
+Mark the current behavior as successful:
+
+```bash
+ros2 topic pub --once /oomwoo/recovery/behavior_result std_msgs/msg/String "{data: succeeded}"
+```
+
+Trigger e-stop:
+
+```bash
+ros2 topic pub --once /oomwoo/safety/e_stop std_msgs/msg/Bool "{data: true}"
+```
+
+## Current limitations
+
+- This is a first integration scaffold, not a full Nav2 behavior-server plugin.
+- `clear_costmap` is published as an intent on `/oomwoo/recovery/command`; a
+  future adapter should call Nav2 costmap clear services directly.
+- Success detection is external for now. If no `succeeded` result arrives before
+  a behavior's timeout, the node escalates to the next behavior and eventually
+  pauses.
+- Cliff, wheel-drop, and pickup are represented as boolean topics until the
+  hardware/simulation message contract is finalized.

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/launch/recovery_safety.launch.py
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/launch/recovery_safety.launch.py
@@ -1,0 +1,15 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="oomwoo_recovery_safety",
+                executable="recovery_safety_node",
+                name="recovery_safety",
+                output="screen",
+            )
+        ]
+    )

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/__init__.py
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/__init__.py
@@ -1,0 +1,1 @@
+"""OOMWOO recovery-safety prototype package."""

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/core.py
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/core.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+import json
+from typing import Mapping
+
+
+class Situation(str, Enum):
+    BUMPER_LEFT = "bumper_left"
+    BUMPER_RIGHT = "bumper_right"
+    BUMPER_FRONT = "bumper_front"
+    WEDGED = "wedged"
+    NO_VALID_PATH = "no_valid_path"
+    LOCALIZATION_LOST = "localization_lost"
+    CLIFF = "cliff"
+    WHEEL_DROP = "wheel_drop"
+    PICKUP = "pickup"
+    E_STOP = "e_stop"
+
+
+class ControllerState(str, Enum):
+    IDLE = "idle"
+    RECOVERING = "recovering"
+    RECOVERED = "recovered"
+    PAUSED = "paused"
+
+
+class DecisionKind(str, Enum):
+    START_STEP = "start_step"
+    STATUS_ONLY = "status_only"
+    IGNORED = "ignored"
+
+
+@dataclass(frozen=True)
+class RecoveryStep:
+    name: str
+    command: str
+    duration_sec: float
+    linear_x: float = 0.0
+    angular_z: float = 0.0
+
+
+@dataclass(frozen=True)
+class RecoveryStatus:
+    state: str
+    reason_code: str
+    message: str
+    recoverable: bool
+    source: str = "oomwoo_recovery_safety"
+    situation: str | None = None
+    behavior: str | None = None
+    step_index: int | None = None
+    ladder_length: int | None = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+
+@dataclass(frozen=True)
+class Decision:
+    kind: DecisionKind
+    status: RecoveryStatus
+    step: RecoveryStep | None = None
+
+
+SAFETY_SITUATIONS = {
+    Situation.CLIFF,
+    Situation.WHEEL_DROP,
+    Situation.PICKUP,
+    Situation.E_STOP,
+}
+
+
+DEFAULT_LADDERS: Mapping[Situation, tuple[RecoveryStep, ...]] = {
+    Situation.BUMPER_LEFT: (
+        RecoveryStep("back_up", "twist", 0.8, linear_x=-0.12),
+        RecoveryStep("rotate_away_from_left_bumper", "twist", 1.0, linear_x=-0.06, angular_z=-0.55),
+        RecoveryStep("wiggle_free", "twist", 0.7, linear_x=-0.04, angular_z=0.85),
+        RecoveryStep("clear_costmap", "clear_costmap", 0.1),
+    ),
+    Situation.BUMPER_RIGHT: (
+        RecoveryStep("back_up", "twist", 0.8, linear_x=-0.12),
+        RecoveryStep("rotate_away_from_right_bumper", "twist", 1.0, linear_x=-0.06, angular_z=0.55),
+        RecoveryStep("wiggle_free", "twist", 0.7, linear_x=-0.04, angular_z=-0.85),
+        RecoveryStep("clear_costmap", "clear_costmap", 0.1),
+    ),
+    Situation.BUMPER_FRONT: (
+        RecoveryStep("back_up", "twist", 0.9, linear_x=-0.14),
+        RecoveryStep("rotate_left", "twist", 0.8, angular_z=0.6),
+        RecoveryStep("rotate_right", "twist", 0.8, angular_z=-0.6),
+        RecoveryStep("clear_costmap", "clear_costmap", 0.1),
+    ),
+    Situation.WEDGED: (
+        RecoveryStep("back_up", "twist", 1.0, linear_x=-0.12),
+        RecoveryStep("wiggle_left", "twist", 0.6, linear_x=-0.04, angular_z=0.9),
+        RecoveryStep("wiggle_right", "twist", 0.6, linear_x=-0.04, angular_z=-0.9),
+        RecoveryStep("rotate_in_place", "twist", 1.2, angular_z=0.7),
+        RecoveryStep("clear_costmap", "clear_costmap", 0.1),
+    ),
+    Situation.NO_VALID_PATH: (
+        RecoveryStep("clear_costmap", "clear_costmap", 0.1),
+        RecoveryStep("nudge_reverse", "twist", 0.6, linear_x=-0.08),
+        RecoveryStep("rotate_in_place", "twist", 1.0, angular_z=0.6),
+    ),
+    Situation.LOCALIZATION_LOST: (
+        RecoveryStep("stop_and_wait", "stop", 0.1),
+        RecoveryStep("rotate_to_collect_scans", "twist", 1.5, angular_z=0.45),
+    ),
+}
+
+
+class RecoveryController:
+    def __init__(self, ladders: Mapping[Situation, tuple[RecoveryStep, ...]] | None = None):
+        self._ladders = dict(ladders or DEFAULT_LADDERS)
+        self._state = ControllerState.IDLE
+        self._situation: Situation | None = None
+        self._step_index = 0
+        self._current_step: RecoveryStep | None = None
+        self._last_status = self._make_status("READY", "Recovery controller ready", True)
+
+    @property
+    def state(self) -> ControllerState:
+        return self._state
+
+    @property
+    def last_status(self) -> RecoveryStatus:
+        return self._last_status
+
+    def trigger(self, situation: Situation | str) -> Decision:
+        parsed = self._parse_situation(situation)
+
+        if parsed in SAFETY_SITUATIONS:
+            return self._pause(
+                parsed,
+                reason_code=self._safety_reason(parsed),
+                message=f"Safety event {parsed.value} paused the robot",
+                recoverable=False,
+            )
+
+        if self._state == ControllerState.RECOVERING:
+            status = self._make_status(
+                "RECOVERY_ALREADY_ACTIVE",
+                f"Ignoring {parsed.value}; already recovering from {self._situation.value}",
+                True,
+            )
+            self._last_status = status
+            return Decision(DecisionKind.IGNORED, status)
+
+        if self._state == ControllerState.PAUSED:
+            status = self._make_status(
+                "RECOVERY_PAUSED",
+                f"Ignoring {parsed.value}; controller is paused and needs reset",
+                self._last_status.recoverable,
+            )
+            self._last_status = status
+            return Decision(DecisionKind.IGNORED, status)
+
+        ladder = self._ladders.get(parsed)
+        if not ladder:
+            return self._pause(
+                parsed,
+                reason_code="NO_RECOVERY_LADDER",
+                message=f"No recovery ladder configured for {parsed.value}",
+                recoverable=True,
+            )
+
+        self._state = ControllerState.RECOVERING
+        self._situation = parsed
+        self._step_index = 0
+        self._current_step = ladder[0]
+        status = self._make_status(
+            "RECOVERY_STARTED",
+            f"Starting recovery step {self._current_step.name}",
+            True,
+        )
+        self._last_status = status
+        return Decision(DecisionKind.START_STEP, status, self._current_step)
+
+    def step_succeeded(self) -> Decision:
+        if self._state != ControllerState.RECOVERING:
+            status = self._make_status("NO_ACTIVE_RECOVERY", "No active recovery to complete", True)
+            self._last_status = status
+            return Decision(DecisionKind.IGNORED, status)
+
+        self._state = ControllerState.RECOVERED
+        self._current_step = None
+        status = self._make_status("RECOVERED", "Recovery succeeded", True)
+        self._last_status = status
+        return Decision(DecisionKind.STATUS_ONLY, status)
+
+    def step_failed(self, detail: str = "step failed") -> Decision:
+        if self._state != ControllerState.RECOVERING or self._situation is None:
+            status = self._make_status("NO_ACTIVE_RECOVERY", "No active recovery to fail", True)
+            self._last_status = status
+            return Decision(DecisionKind.IGNORED, status)
+
+        ladder = self._ladders[self._situation]
+        next_index = self._step_index + 1
+        if next_index >= len(ladder):
+            return self._pause(
+                self._situation,
+                reason_code="RECOVERY_EXHAUSTED",
+                message=f"Recovery ladder exhausted after {detail}",
+                recoverable=True,
+            )
+
+        self._step_index = next_index
+        self._current_step = ladder[next_index]
+        status = self._make_status(
+            "RECOVERY_ESCALATED",
+            f"Escalating after {detail}; starting {self._current_step.name}",
+            True,
+        )
+        self._last_status = status
+        return Decision(DecisionKind.START_STEP, status, self._current_step)
+
+    def reset(self) -> Decision:
+        self._state = ControllerState.IDLE
+        self._situation = None
+        self._step_index = 0
+        self._current_step = None
+        status = self._make_status("READY", "Recovery controller reset", True)
+        self._last_status = status
+        return Decision(DecisionKind.STATUS_ONLY, status)
+
+    def _pause(
+        self,
+        situation: Situation,
+        *,
+        reason_code: str,
+        message: str,
+        recoverable: bool,
+    ) -> Decision:
+        self._state = ControllerState.PAUSED
+        self._situation = situation
+        self._current_step = None
+        status = self._make_status(reason_code, message, recoverable)
+        self._last_status = status
+        return Decision(DecisionKind.STATUS_ONLY, status)
+
+    def _make_status(self, reason_code: str, message: str, recoverable: bool) -> RecoveryStatus:
+        ladder_length = None
+        if self._situation in self._ladders:
+            ladder_length = len(self._ladders[self._situation])
+
+        return RecoveryStatus(
+            state=self._state.value,
+            reason_code=reason_code,
+            message=message,
+            recoverable=recoverable,
+            situation=self._situation.value if self._situation else None,
+            behavior=self._current_step.name if self._current_step else None,
+            step_index=self._step_index if self._current_step else None,
+            ladder_length=ladder_length,
+        )
+
+    @staticmethod
+    def _parse_situation(situation: Situation | str) -> Situation:
+        if isinstance(situation, Situation):
+            return situation
+        try:
+            return Situation(str(situation).strip().lower())
+        except ValueError as exc:
+            raise ValueError(f"Unknown recovery situation: {situation}") from exc
+
+    @staticmethod
+    def _safety_reason(situation: Situation) -> str:
+        if situation == Situation.E_STOP:
+            return "E_STOP"
+        return f"SAFETY_{situation.value.upper()}"

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/recovery_node.py
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/recovery_node.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from time import monotonic
+
+from geometry_msgs.msg import Twist
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.exceptions import ROSInterruptException
+from rclpy.node import Node
+from ros_gz_interfaces.msg import Contacts
+from std_msgs.msg import Bool, String
+
+from oomwoo_recovery_safety.core import Decision, DecisionKind, RecoveryController, Situation
+
+
+class RecoverySafetyNode(Node):
+    def __init__(self):
+        super().__init__("recovery_safety")
+        self._controller = RecoveryController()
+        self._active_deadline: float | None = None
+
+        self._cmd_pub = self.create_publisher(Twist, "cmd_vel", 10)
+        self._status_pub = self.create_publisher(String, "oomwoo/status", 10)
+        self._command_pub = self.create_publisher(String, "oomwoo/recovery/command", 10)
+
+        self.create_subscription(Contacts, "bumper_left", self._bumper_left_cb, 10)
+        self.create_subscription(Contacts, "bumper_right", self._bumper_right_cb, 10)
+        self.create_subscription(String, "oomwoo/recovery/event", self._event_cb, 10)
+        self.create_subscription(String, "oomwoo/recovery/behavior_result", self._behavior_result_cb, 10)
+        self.create_subscription(Bool, "oomwoo/safety/e_stop", self._e_stop_cb, 10)
+        self.create_subscription(Bool, "oomwoo/safety/cliff", self._cliff_cb, 10)
+        self.create_subscription(Bool, "oomwoo/safety/wheel_drop", self._wheel_drop_cb, 10)
+        self.create_subscription(Bool, "oomwoo/safety/pickup", self._pickup_cb, 10)
+        self.create_subscription(Bool, "oomwoo/recovery/reset", self._reset_cb, 10)
+
+        self.create_timer(0.05, self._timer_cb)
+        self._publish_status(self._controller.last_status)
+
+    def _bumper_left_cb(self, msg: Contacts):
+        if self._has_real_contact(msg):
+            self._execute(self._controller.trigger(Situation.BUMPER_LEFT))
+
+    def _bumper_right_cb(self, msg: Contacts):
+        if self._has_real_contact(msg):
+            self._execute(self._controller.trigger(Situation.BUMPER_RIGHT))
+
+    def _event_cb(self, msg: String):
+        try:
+            self._execute(self._controller.trigger(msg.data))
+        except ValueError as exc:
+            self.get_logger().warn(str(exc))
+
+    def _behavior_result_cb(self, msg: String):
+        outcome = self._parse_outcome(msg.data)
+        if outcome == "succeeded":
+            self._stop_motion()
+            self._active_deadline = None
+            self._execute(self._controller.step_succeeded())
+        elif outcome == "failed":
+            self._stop_motion()
+            self._active_deadline = None
+            self._execute(self._controller.step_failed("external failure result"))
+        else:
+            self.get_logger().warn(f"Ignoring unknown behavior outcome: {msg.data}")
+
+    def _e_stop_cb(self, msg: Bool):
+        if msg.data:
+            self._stop_motion()
+            self._active_deadline = None
+            self._execute(self._controller.trigger(Situation.E_STOP))
+
+    def _cliff_cb(self, msg: Bool):
+        if msg.data:
+            self._stop_motion()
+            self._active_deadline = None
+            self._execute(self._controller.trigger(Situation.CLIFF))
+
+    def _wheel_drop_cb(self, msg: Bool):
+        if msg.data:
+            self._stop_motion()
+            self._active_deadline = None
+            self._execute(self._controller.trigger(Situation.WHEEL_DROP))
+
+    def _pickup_cb(self, msg: Bool):
+        if msg.data:
+            self._stop_motion()
+            self._active_deadline = None
+            self._execute(self._controller.trigger(Situation.PICKUP))
+
+    def _reset_cb(self, msg: Bool):
+        if msg.data:
+            self._stop_motion()
+            self._active_deadline = None
+            self._execute(self._controller.reset())
+
+    def _timer_cb(self):
+        if self._active_deadline is None or monotonic() < self._active_deadline:
+            return
+
+        self._stop_motion()
+        self._active_deadline = None
+        self._execute(self._controller.step_failed("behavior timeout"))
+
+    def _execute(self, decision: Decision):
+        self._publish_status(decision.status)
+        if decision.kind != DecisionKind.START_STEP or decision.step is None:
+            return
+
+        step = decision.step
+        if step.command == "twist":
+            twist = Twist()
+            twist.linear.x = step.linear_x
+            twist.angular.z = step.angular_z
+            self._cmd_pub.publish(twist)
+        elif step.command == "stop":
+            self._stop_motion()
+        else:
+            self._publish_command(step.command, step.name)
+
+        self._active_deadline = monotonic() + step.duration_sec
+
+    def _publish_status(self, status):
+        self._status_pub.publish(String(data=status.to_json()))
+
+    def _publish_command(self, command: str, behavior: str):
+        payload = {
+            "command": command,
+            "behavior": behavior,
+            "source": "oomwoo_recovery_safety",
+        }
+        self._command_pub.publish(String(data=json.dumps(payload, sort_keys=True)))
+
+    def _stop_motion(self):
+        self._cmd_pub.publish(Twist())
+
+    @staticmethod
+    def _has_real_contact(msg: Contacts) -> bool:
+        for contact in msg.contacts:
+            names = {contact.collision1.name, contact.collision2.name}
+            if not any("ground_plane" in name.split("::") for name in names):
+                return True
+        return False
+
+    @staticmethod
+    def _parse_outcome(raw: str) -> str:
+        value = raw.strip().lower()
+        if value.startswith("{"):
+            try:
+                value = str(json.loads(raw).get("outcome", "")).strip().lower()
+            except json.JSONDecodeError:
+                return ""
+        return value
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = RecoverySafetyNode()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException, ROSInterruptException):
+        pass
+    except Exception as exc:
+        if "context is not valid" not in str(exc):
+            raise
+    finally:
+        node.destroy_node()
+        try:
+            if rclpy.ok():
+                rclpy.shutdown()
+        except Exception as exc:
+            if "rcl_shutdown already called" not in str(exc):
+                raise

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/package.xml
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>oomwoo_recovery_safety</name>
+  <version>0.1.0</version>
+  <description>Bounded recovery ladder and safety pause node for OOMWOO.</description>
+
+  <maintainer email="xbattlax@gmail.com">xbattlax</maintainer>
+  <license>Apache-2.0</license>
+
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros_gz_interfaces</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/resource/oomwoo_recovery_safety
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/resource/oomwoo_recovery_safety
@@ -1,0 +1,1 @@
+oomwoo_recovery_safety

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/setup.cfg
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/oomwoo_recovery_safety
+[install]
+install_scripts=$base/lib/oomwoo_recovery_safety

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/setup.py
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/setup.py
@@ -1,0 +1,27 @@
+from setuptools import find_packages, setup
+
+
+package_name = "oomwoo_recovery_safety"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+        ("share/" + package_name + "/launch", ["launch/recovery_safety.launch.py"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="xbattlax",
+    maintainer_email="xbattlax@gmail.com",
+    description="Bounded recovery ladder and safety pause node for OOMWOO.",
+    license="Apache-2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "recovery_safety_node = oomwoo_recovery_safety.recovery_node:main",
+        ],
+    },
+)

--- a/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/test/test_recovery_controller.py
+++ b/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/test/test_recovery_controller.py
@@ -1,0 +1,109 @@
+import json
+
+import pytest
+
+from oomwoo_recovery_safety.core import ControllerState, DecisionKind, RecoveryController, Situation
+
+
+def test_bumper_recovery_escalates_and_terminates():
+    controller = RecoveryController()
+
+    decision = controller.trigger(Situation.BUMPER_LEFT)
+    assert decision.kind == DecisionKind.START_STEP
+    assert decision.step.name == "back_up"
+
+    seen = [decision.step.name]
+    for _ in range(10):
+        decision = controller.step_failed("test failure")
+        if decision.kind == DecisionKind.START_STEP:
+            seen.append(decision.step.name)
+            continue
+        break
+
+    assert seen == [
+        "back_up",
+        "rotate_away_from_left_bumper",
+        "wiggle_free",
+        "clear_costmap",
+    ]
+    assert controller.state == ControllerState.PAUSED
+    assert controller.last_status.reason_code == "RECOVERY_EXHAUSTED"
+    assert controller.last_status.recoverable is True
+
+
+def test_success_stops_ladder():
+    controller = RecoveryController()
+    controller.trigger("bumper_front")
+
+    decision = controller.step_succeeded()
+
+    assert decision.kind == DecisionKind.STATUS_ONLY
+    assert controller.state == ControllerState.RECOVERED
+    assert controller.last_status.reason_code == "RECOVERED"
+
+
+@pytest.mark.parametrize(
+    ("situation", "reason"),
+    [
+        (Situation.E_STOP, "E_STOP"),
+        (Situation.CLIFF, "SAFETY_CLIFF"),
+        (Situation.WHEEL_DROP, "SAFETY_WHEEL_DROP"),
+        (Situation.PICKUP, "SAFETY_PICKUP"),
+    ],
+)
+def test_safety_events_pause_immediately(situation, reason):
+    controller = RecoveryController()
+
+    decision = controller.trigger(situation)
+
+    assert decision.kind == DecisionKind.STATUS_ONLY
+    assert controller.state == ControllerState.PAUSED
+    assert controller.last_status.reason_code == reason
+    assert controller.last_status.recoverable is False
+
+
+def test_duplicate_trigger_is_ignored_while_recovering():
+    controller = RecoveryController()
+    controller.trigger(Situation.BUMPER_RIGHT)
+
+    decision = controller.trigger(Situation.WEDGED)
+
+    assert decision.kind == DecisionKind.IGNORED
+    assert controller.state == ControllerState.RECOVERING
+    assert controller.last_status.reason_code == "RECOVERY_ALREADY_ACTIVE"
+
+
+def test_reset_returns_to_idle_after_pause():
+    controller = RecoveryController()
+    controller.trigger(Situation.E_STOP)
+
+    decision = controller.reset()
+
+    assert decision.kind == DecisionKind.STATUS_ONLY
+    assert controller.state == ControllerState.IDLE
+    assert controller.last_status.reason_code == "READY"
+
+
+def test_paused_controller_ignores_new_recovery_until_reset():
+    controller = RecoveryController()
+    controller.trigger(Situation.E_STOP)
+
+    decision = controller.trigger(Situation.BUMPER_LEFT)
+
+    assert decision.kind == DecisionKind.IGNORED
+    assert controller.state == ControllerState.PAUSED
+    assert controller.last_status.reason_code == "RECOVERY_PAUSED"
+
+
+def test_status_json_shape():
+    controller = RecoveryController()
+    controller.trigger(Situation.NO_VALID_PATH)
+
+    payload = json.loads(controller.last_status.to_json())
+
+    assert payload["state"] == "recovering"
+    assert payload["reason_code"] == "RECOVERY_STARTED"
+    assert payload["recoverable"] is True
+    assert payload["source"] == "oomwoo_recovery_safety"
+    assert payload["situation"] == "no_valid_path"
+    assert payload["behavior"] == "clear_costmap"


### PR DESCRIPTION
## Summary
- add `contributions/recovery-safety/xbattlax/oomwoo_recovery_safety`, a ROS2 Python package for the recovery-safety RFC
- implement a pure-Python bounded recovery ladder core with escalation, pause-and-alert, safety stop, reset, and structured JSON status
- add a ROS2 node that subscribes to Gazebo bumper contacts plus safety/test topics, publishes bounded `/cmd_vel` recovery commands, `/oomwoo/status`, and `/oomwoo/recovery/command`
- document package interfaces, build/test/run commands, and current limitations
- add regression tests covering guaranteed termination, successful recovery, e-stop/safety pause, paused-state reset behavior, duplicate-trigger handling, and status JSON shape

## Testing
- `python3 -m py_compile contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/core.py contributions/recovery-safety/xbattlax/oomwoo_recovery_safety/oomwoo_recovery_safety/recovery_node.py`
- `git diff --check`
- `docker exec -u 503:20 oomwoo-ros2-dev bash -lc 'cd /workspace/contributions/recovery-safety/xbattlax/oomwoo_recovery_safety && PYTHONPATH=. python3 -m pytest -q test'`
- `docker exec -u 503:20 oomwoo-ros2-dev bash -lc 'source /opt/ros/jazzy/setup.bash && cd /workspace && colcon --log-base /tmp/oomwoo-recovery-colcon-log build --base-paths contributions/recovery-safety/xbattlax/oomwoo_recovery_safety --packages-select oomwoo_recovery_safety --build-base /tmp/oomwoo-recovery-build --install-base /tmp/oomwoo-recovery-install'`
- `docker exec -u 503:20 oomwoo-ros2-dev bash -lc 'source /opt/ros/jazzy/setup.bash && cd /workspace && colcon --log-base /tmp/oomwoo-recovery-test-log test --base-paths contributions/recovery-safety/xbattlax/oomwoo_recovery_safety --packages-select oomwoo_recovery_safety --build-base /tmp/oomwoo-recovery-build --install-base /tmp/oomwoo-recovery-install --test-result-base /tmp/oomwoo-recovery-test-results && colcon test-result --test-result-base /tmp/oomwoo-recovery-test-results --verbose'`
- `docker exec -u 503:20 oomwoo-ros2-dev bash -lc 'export HOME=/tmp && source /opt/ros/jazzy/setup.bash && source /tmp/oomwoo-recovery-install/setup.bash && timeout 3s ros2 run oomwoo_recovery_safety recovery_safety_node'` (expected timeout after clean startup)