### PR TITLE
Add compute benchmark plan for ROS2 memory reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ until OOMWOO hardware is ready. Pick one, tell us in
 | Localization & navigation on a known map | [nav-localize](./contributions/nav-localize) | Ready to start work | Nav2 nav, AMCL localization, relocalize when lost, resume map |
 | Dock cycle: undock, dock, recharge | [dock-cycle](./contributions/dock-cycle) | Ready to start work | Undock, return-to-dock, precise docking, station services, find dock when lost |
 | Recovery behaviors & safety | [recovery-safety](./contributions/recovery-safety) | Ready to start work | Recovery ladder, escalation, pause-and-alert, safety sensors, status reporting |
+| Compute benchmark & memory reduction | [compute-benchmark](./contributions/compute-benchmark) | In progress | Measure ROS2/Nav2/SLAM memory, compare composable nodes, and track the 4 GB -> 2 GB target |
 | Floor-surface handling & edge cleaning | [floor-care](./contributions/floor-care) | Ready to start work | Wall/edge following, carpet vs hardwood, mop lift/lower |
 | Cleaning modes, zones & job orchestration | [cleaning-jobs](./contributions/cleaning-jobs) | Ready to start work | Modes (regular/spot), virtual walls, room segmentation, job splitting + resume |
 | Live robot bring-up & validation | [live-robot-bringup](./contributions/live-robot-bringup) | Ready to start work | Connect the placeholder Proscenic M6 Pro to ROS2, re-run sim tests on hardware |

--- a/contributions/compute-benchmark/README.md
+++ b/contributions/compute-benchmark/README.md
@@ -1,0 +1,86 @@
+# Compute Benchmark & Memory Reduction
+
+Measure whether OOMWOO can keep ROS2/Nav2/SLAM onboard while reducing the
+minimum compute target from a comfortable 4 GB class system toward a practical
+2 GB class system.
+
+This module is for repeatable measurements, not guesses. It should help compare
+Python/C++ ROS2 nodes, ROS2 composable-node layouts where supported, process
+layout changes, and later optional Rust experiments under the same workload.
+
+> Status: in progress. Use the ROS2 Jazzy development container and the current
+> simulation stack where possible. Hardware runs on Pi 4, CM4, CM5, or compatible
+> modules are especially useful when available.
+
+## Current Working Assumptions
+
+- The consumer vacuum profile keeps SLAM and navigation onboard.
+- The practical near-term target is Pi 4 / CM4-class compute with 4 GB RAM.
+- The stretch target is to reduce the minimum memory requirement toward 2 GB
+  without giving up ROS2.
+- The compute-module direction is CM4/CM5 or compatible modules on a carrier
+  board; ignore the older RK3562 reference path.
+- The MCU owns motors, sensors, safety, battery/charging supervision, watchdogs,
+  and the custom serial protocol.
+- STM32G070RBT6 is a strong MCU candidate because of its GPIO/ADC count, low
+  cost, and LQFP manufacturability, while the MCU choice remains reviewable.
+- The MVP 2D LiDAR target is 5 Hz with no scan dropping.
+- Rust/rclrs is an optional late-summer integration candidate, not a baseline
+  dependency today.
+
+Context: this module follows the compute discussion in
+[issue #18](https://github.com/makerspet/oomwoo/issues/18).
+
+## Request For Contribution
+
+Submit a benchmark contribution under:
+
+```text
+contributions/compute-benchmark/<your-github-username>/
+```
+
+Include:
+
+- a reproducible benchmark plan
+- scripts that capture RSS/PSS/CPU/startup timing where possible
+- a hardware/software run matrix
+- a compute BOM table with regional price and stock fields
+- clear notes on ROS distro, RMW, hardware, RAM size, LiDAR rate, and scenario
+- a short decision record after measurements
+
+## Metrics
+
+Minimum useful metrics:
+
+| Metric | Why it matters |
+|---|---|
+| RSS/PSS per process | Shows where memory is actually going. |
+| CPU idle / mapping / navigation | Separates always-on cost from workload cost. |
+| Startup time | Exposes heavy node initialization and launch overhead. |
+| LiDAR update rate | Confirms the benchmark is not cheating by dropping scans. |
+| Nav2/SLAM headroom | Determines whether 2 GB is plausible with ROS2 retained. |
+| Recovery-event latency | Keeps safety-adjacent nodes honest under optimization. |
+
+## Strategies To Compare
+
+1. Current Python/C++ baseline.
+2. ROS2 composable nodes where supported, plus launch/process layout changes.
+3. C++/rclcpp for selected hot or always-on custom nodes.
+4. Optional Rust/rclrs spike for selected custom nodes after dev-image setup is
+   reproducible.
+
+Rust should only move from optional to recommended if it demonstrates a useful
+RSS/PSS or latency improvement and does not make the default Jazzy developer
+experience fragile.
+
+## Acceptance Criteria
+
+- Measurements are reproducible by another contributor.
+- The benchmark records hardware, RAM, ROS distro, RMW, scenario, and git SHA.
+- Results distinguish process RSS from PSS when PSS is available.
+- Benchmarks do not reduce LiDAR update rate below the target unless explicitly
+  marked as an experiment.
+- The contribution explains whether the result supports 4 GB only, 2 GB as a
+  stretch target, or a different hardware class.
+- BOM notes include module/board, carrier, power, cooling, storage, MCU add-ons,
+  regional price, and stock status.

--- a/contributions/compute-benchmark/xbattlax/README.md
+++ b/contributions/compute-benchmark/xbattlax/README.md
@@ -1,0 +1,100 @@
+# Compute Benchmark Plan by xbattlax
+
+This contribution turns the compute discussion in issue #18 into a concrete
+benchmark scaffold for OOMWOO.
+
+The immediate goal is to measure whether OOMWOO can keep onboard ROS2, Nav2, and
+SLAM while reducing the practical memory target from 4 GB toward 2 GB. The first
+optimization path should be ROS2 composable nodes where supported, plus
+launch/process layout. Rust with rclrs is kept as a serious optional spike for
+late August / September 2026, gated by measurements and dev-image
+reproducibility.
+
+## Scope
+
+Included:
+
+- a Linux `/proc`-based process sampler for RSS/PSS/CPU
+- a run matrix template for repeatable benchmark scenarios
+- a compute BOM template for board/module, carrier, power, cooling, storage,
+  MCU add-ons, regional pricing, and stock status
+- a short architecture decision record for the current memory-reduction plan
+
+Not included yet:
+
+- a Rust/rclrs node implementation
+- a C++/rclcpp equivalent node
+- physical Pi 4 / CM4 / CM5 results
+- automated launch files for full SLAM/Nav2 runs
+
+## Hardware Profiles To Record
+
+| Profile | Purpose | Notes |
+|---|---|---|
+| Dev machine | Reference only | Useful for repeatability, not a robot target. |
+| Pi 4 4 GB | Minimum prior-art target | Validate onboard SLAM/Nav2 feasibility. |
+| CM4 4 GB | Consumer carrier-board target | Low profile and product-friendly. |
+| CM5 4 GB+ | Higher headroom target | Useful if camera/NPU alternatives are evaluated. |
+| 2 GB class SBC/module | Stretch target | Requires real measured headroom, not assumptions. |
+| ESP32 educational profile | Offboard ROS2/SLAM learning setup | Not a consumer autonomous vacuum profile. |
+
+## Measurement Scenarios
+
+Start with these scenarios:
+
+1. ROS2 graph idle after launch.
+2. SLAM running with 5 Hz LiDAR input and no scan dropping.
+3. Nav2 navigating on a known map.
+4. Recovery/safety node idle.
+5. Recovery/safety event burst.
+6. Same workload after composable-node or process-layout changes.
+7. Later: same selected custom node in Python, C++/rclcpp, and Rust/rclrs.
+
+## Using The Sampler
+
+Run this inside the Linux ROS2 environment while the target workload is already
+running:
+
+```bash
+bash contributions/compute-benchmark/xbattlax/scripts/measure_ros_processes.sh \
+  --pattern 'ros2|component_container|python3|slam_toolbox|nav2' \
+  --duration 60 \
+  --interval 2 \
+  --label slam_5hz_baseline \
+  --output /tmp/oomwoo-slam-5hz-baseline.csv
+```
+
+The script writes CSV with:
+
+- timestamp
+- sample index
+- label
+- PID
+- process name
+- CPU percent
+- RSS KiB
+- PSS KiB when `/proc/<pid>/smaps_rollup` is available
+- command line
+
+PSS is usually more useful than RSS for ROS2 systems because shared libraries and
+middleware pages can make RSS look worse than the actual proportional memory
+pressure.
+
+## Templates
+
+- `templates/run_matrix.csv`: planned benchmark runs and environment details.
+- `templates/compute_bom.csv`: compute BOM and regional stock/price snapshot.
+
+Copy the templates into a results folder for real benchmark submissions. Do not
+edit old result rows after a run; add a new row for a new measurement.
+
+## Expected Decision Output
+
+Each benchmark batch should end with a short note:
+
+- current measured minimum RAM class
+- biggest memory users
+- whether composable nodes helped
+- whether any Python node is worth porting to C++ or Rust
+- whether Rust/rclrs setup is reproducible enough to keep testing
+- what hardware profile the result supports

--- a/contributions/compute-benchmark/xbattlax/docs/adr-0001-memory-reduction-strategy.md
+++ b/contributions/compute-benchmark/xbattlax/docs/adr-0001-memory-reduction-strategy.md
@@ -1,0 +1,58 @@
+# ADR 0001: Memory-Reduction Strategy
+
+## Status
+
+Proposed.
+
+## Context
+
+OOMWOO should remain approachable for builders, so the first consumer vacuum
+profile should run SLAM and navigation onboard. Requiring a separate workstation
+for mapping would make the regular product harder to build and use.
+
+The maintainer has clarified these current assumptions:
+
+- Pi 4 / CM4-class compute with 4 GB RAM is a realistic near-term baseline.
+- Reducing toward 2 GB while keeping ROS2 would be valuable.
+- CM4/CM5 or compatible modules are the compute-module direction.
+- The older RK3562 reference schematic should be ignored for new compute-module
+  planning.
+- The MCU role is fixed around motors, sensors, safety, battery/charging
+  control, watchdogs, and custom serial protocol.
+- ESP32/micro-ROS is better suited to an educational/offboard profile than to
+  the consumer safety/controller role.
+
+## Decision
+
+Use this priority order for memory-reduction work:
+
+1. Measure the current Python/C++ ROS2 baseline.
+2. Try ROS2 composable nodes where supported, plus launch/process layout
+   improvements first.
+3. Consider C++/rclcpp for selected memory-heavy or latency-sensitive custom
+   nodes when composable layout is insufficient.
+4. Keep Rust/rclrs as an optional late-summer 2026 spike for selected custom
+   nodes, not as a baseline dependency today.
+
+Rust/rclrs should be evaluated seriously, but only promoted if:
+
+- RSS/PSS or latency wins are meaningful against Python and C++ baselines
+- the Jazzy build/setup is reproducible in the OOMWOO dev image
+- contributor onboarding remains reasonable
+- the node selected for porting is small enough to keep the experiment bounded
+
+## Consequences
+
+- The first benchmark contribution can avoid adding Rust dependencies.
+- The benchmark still leaves a clear path for a later rclrs experiment.
+- The project can pursue the 4 GB -> 2 GB target with lower dependency risk.
+- Results should identify whether memory pressure comes from custom Python
+  nodes, ROS2 process layout, Nav2/SLAM, or other runtime overhead.
+
+## Open Questions
+
+- Which launch graph should be the canonical benchmark workload?
+- Which ROS2 RMW should be the baseline for memory measurements?
+- Which node is the best first Rust/rclrs candidate if measurements justify it?
+- How should PSS be collected on target hardware when permissions differ?
+- What minimum headroom should qualify a 2 GB target as realistic?

--- a/contributions/compute-benchmark/xbattlax/scripts/measure_ros_processes.sh
+++ b/contributions/compute-benchmark/xbattlax/scripts/measure_ros_processes.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  measure_ros_processes.sh --pattern REGEX [options]
+
+Options:
+  --pattern REGEX      Process command-line regex to sample. Required.
+  --duration SECONDS   Total sample duration. Default: 30.
+  --interval SECONDS   Seconds between samples. Default: 1.
+  --label LABEL        Free-form label written to each row. Default: run.
+  --output FILE        CSV output path. Default: stdout.
+  --help               Show this help.
+
+Examples:
+  bash measure_ros_processes.sh \
+    --pattern 'ros2|component_container|python3|slam_toolbox|nav2' \
+    --duration 60 \
+    --interval 2 \
+    --label slam_5hz_baseline \
+    --output /tmp/oomwoo-slam-5hz-baseline.csv
+
+Notes:
+  This script is intended for Linux ROS2 targets. It reads /proc for RSS and
+  PSS. PSS is blank when /proc/<pid>/smaps_rollup is not readable.
+EOF
+}
+
+pattern=""
+duration="30"
+interval="1"
+label="run"
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pattern)
+      pattern="${2:-}"
+      shift 2
+      ;;
+    --duration)
+      duration="${2:-}"
+      shift 2
+      ;;
+    --interval)
+      interval="${2:-}"
+      shift 2
+      ;;
+    --label)
+      label="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$pattern" ]]; then
+  echo "--pattern is required" >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -d /proc ]]; then
+  echo "This sampler requires Linux /proc." >&2
+  exit 1
+fi
+
+if ! [[ "$duration" =~ ^[0-9]+$ ]] || [[ "$duration" -lt 1 ]]; then
+  echo "--duration must be a positive integer" >&2
+  exit 2
+fi
+
+if ! [[ "$interval" =~ ^[0-9]+$ ]] || [[ "$interval" -lt 1 ]]; then
+  echo "--interval must be a positive integer" >&2
+  exit 2
+fi
+
+csv_escape() {
+  local value="${1:-}"
+  value="${value//$'\n'/ }"
+  value="${value//$'\r'/ }"
+  value="${value//\"/\"\"}"
+  printf '"%s"' "$value"
+}
+
+read_status_kib() {
+  local pid="$1"
+  local key="$2"
+  awk -v key="$key" '$1 == key ":" { print $2; found=1; exit } END { if (!found) print "" }' "/proc/$pid/status" 2>/dev/null || true
+}
+
+read_pss_kib() {
+  local pid="$1"
+  if [[ -r "/proc/$pid/smaps_rollup" ]]; then
+    awk '$1 == "Pss:" { print $2; found=1; exit } END { if (!found) print "" }' "/proc/$pid/smaps_rollup" 2>/dev/null || true
+  fi
+}
+
+read_cmdline() {
+  local pid="$1"
+  if [[ -r "/proc/$pid/cmdline" ]]; then
+    tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | sed 's/[[:space:]]*$//'
+  fi
+}
+
+read_comm() {
+  local pid="$1"
+  if [[ -r "/proc/$pid/comm" ]]; then
+    tr -d '\n' < "/proc/$pid/comm" 2>/dev/null
+  fi
+}
+
+read_cpu_percent() {
+  local pid="$1"
+  ps -p "$pid" -o %cpu= 2>/dev/null | awk '{ print $1 }'
+}
+
+emit_header() {
+  printf 'timestamp_utc,sample_index,label,pid,comm,cpu_percent,rss_kib,pss_kib,cmdline\n'
+}
+
+emit_row() {
+  local timestamp="$1"
+  local sample_index="$2"
+  local pid="$3"
+  local comm="$4"
+  local cpu_percent="$5"
+  local rss_kib="$6"
+  local pss_kib="$7"
+  local cmdline="$8"
+
+  printf '%s,%s,' "$timestamp" "$sample_index"
+  csv_escape "$label"
+  printf ',%s,' "$pid"
+  csv_escape "$comm"
+  printf ',%s,%s,%s,' "$cpu_percent" "$rss_kib" "$pss_kib"
+  csv_escape "$cmdline"
+  printf '\n'
+}
+
+run_sampler() {
+  local sample_index=0
+  local started="$SECONDS"
+
+  emit_header
+
+  while (( SECONDS - started <= duration )); do
+    local timestamp
+    timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+    mapfile -t pids < <(
+      for proc in /proc/[0-9]*; do
+        pid="${proc##*/}"
+        cmdline="$(read_cmdline "$pid")"
+        if [[ -n "$cmdline" && "$cmdline" =~ $pattern ]]; then
+          printf '%s\n' "$pid"
+        fi
+      done
+    )
+
+    if [[ "${#pids[@]}" -eq 0 ]]; then
+      emit_row "$timestamp" "$sample_index" "" "no_process_match" "" "" "" ""
+    else
+      local pid
+      for pid in "${pids[@]}"; do
+        if [[ ! -d "/proc/$pid" ]]; then
+          continue
+        fi
+        emit_row \
+          "$timestamp" \
+          "$sample_index" \
+          "$pid" \
+          "$(read_comm "$pid")" \
+          "$(read_cpu_percent "$pid")" \
+          "$(read_status_kib "$pid" VmRSS)" \
+          "$(read_pss_kib "$pid")" \
+          "$(read_cmdline "$pid")"
+      done
+    fi
+
+    sample_index=$((sample_index + 1))
+    if (( SECONDS - started >= duration )); then
+      break
+    fi
+    sleep "$interval"
+  done
+}
+
+if [[ -n "$output" ]]; then
+  mkdir -p "$(dirname "$output")"
+  run_sampler > "$output"
+else
+  run_sampler
+fi

--- a/contributions/compute-benchmark/xbattlax/templates/compute_bom.csv
+++ b/contributions/compute-benchmark/xbattlax/templates/compute_bom.csv
@@ -1,0 +1,7 @@
+hardware_profile,role,part,sku_or_module,quantity,unit_price,currency,regional_source_url,stock_status,power_notes,cooling_notes,storage_or_carrier_notes,notes
+CM4_4GB,compute,Compute Module 4,,,,,,,,,,
+CM5_4GB,compute,Compute Module 5,,,,,,,,,,
+Pi4_4GB,compute,Raspberry Pi 4 4GB,,,,,,,,,,
+TwoGB_stretch,compute,2GB SBC or module,,,,,,,,,,
+Consumer_MCU,safety_controller,STM32G070RBT6,,,,,,,,,,
+Educational_ESP32,micro_ros_bridge,ESP32 board,,,,,,,,,,

--- a/contributions/compute-benchmark/xbattlax/templates/run_matrix.csv
+++ b/contributions/compute-benchmark/xbattlax/templates/run_matrix.csv
@@ -1,0 +1,8 @@
+run_id,date_utc,git_sha,hardware_profile,ram_gb,ros_distro,rmw,scenario,node_strategy,lidar_hz,scan_dropping,command_or_launch,expected_duration_s,notes
+baseline_idle,,,,,jazzy,,ros_graph_idle,python_cpp_baseline,5,no,,60,
+slam_5hz,,,,,jazzy,,slam_mapping,python_cpp_baseline,5,no,,300,
+nav_known_map,,,,,jazzy,,nav2_known_map,python_cpp_baseline,5,no,,300,
+recovery_idle,,,,,jazzy,,recovery_safety_idle,python_cpp_baseline,5,no,,60,
+recovery_burst,,,,,jazzy,,recovery_safety_event_burst,python_cpp_baseline,5,no,,60,
+composable_idle,,,,,jazzy,,ros_graph_idle,composable_nodes,5,no,,60,
+rust_spike_late_summer,,,,,jazzy,,selected_custom_node,rust_rclrs_optional,5,no,,60,


### PR DESCRIPTION
## Summary

- add a `compute-benchmark` contribution module focused on ROS2 memory reduction
- add an `xbattlax` benchmark scaffold with RSS/PSS/CPU sampler, run matrix, BOM template, and ADR
- document the current direction from issue #18: CM4/CM5-class compute, STM32G070 MCU, 4 GB baseline, 2 GB stretch target, and optional late-summer Rust/rclrs spike

## Notes

This does not add Rust/rclrs as a dependency. The first path is measurement and ROS2 composable/process-layout benchmarking. Rust remains an optional candidate if later measurements justify it and the Jazzy dev-image setup is reproducible.

Related: #18

## Verification

- `bash -n contributions/compute-benchmark/xbattlax/scripts/measure_ros_processes.sh`
- `git diff --cached --check`
- smoke-tested the sampler in the existing OOMWOO ROS2 Docker container; it produced CSV rows with RSS/PSS/CPU fields
