### PR TITLE
part-specs: consolidate I/O board, caster, side brush, charging, and wall/carpet specs

### DIFF
--- a/contributions/part-specs/OsakaTX/README.md
+++ b/contributions/part-specs/OsakaTX/README.md
@@ -375,6 +375,8 @@ Start byte `0xAA`, followed by:
 
 **⚠️ BOM specifies a Roomba-style caster** (iRobot part #4624869, $2.50-$5 push-in ball-type). The Roborock S-family caster (50mm wheel-type, OEM #9.01.1272/1273) is a different part — verify which is selected before designing the mount.
 
+> **Note on Roborock caster SKUs:** replacement listings cite more than one OEM number for the S-family caster — `9.01.1272/1273` (~50mm wheel, ~45mm base) above, and `HA00021` (~46 × 52mm) in [`io-board-wheel-connector-and-caster.md`](io-board-wheel-connector-and-caster.md). These appear to be the same donor part under different reseller SKUs; the BOM's primary remains the Roomba-style iRobot 4624869. Confirm the exact SKU and dimensions against the selected part before designing the mount.
+
 ### Roomba Caster (BOM Source)
 
 | Spec | Value |
@@ -514,7 +516,7 @@ Active reflective proximity sensor: a 940nm IR LED emits 38kHz-modulated bursts 
 
 | Parameter | Value | Source |
 |-----------|-------|--------|
-| Transducer | HTW HT-300PLTR — 290±15kHz center, 16mm diameter, ~30mm target distance, ≤2mm precision, IP67 | HTW listing (Made-in-China) |
+| Transducer | HTW HT-300PLTR1612-1 — 290±15kHz center, 16mm diameter, ~30mm target distance, ≤2mm precision, IP67 | HTW listing (Made-in-China) |
 | OEM alternative | Roborock OEM carpet sensor module (~$6.93) | AliExpress listing |
 | Principle | Echo-characteristic analysis to distinguish carpet from hard floor | — |
 
@@ -537,4 +539,4 @@ Active reflective proximity sensor: a 940nm IR LED emits 38kHz-modulated bursts 
 | **Charging contacts (dock)** | Gold-plated pogo pins, 4A rating; dock outputs 20V 1.2A (24W) | ❌ Exact pogo pin model/part number, ❌ pricing |
 | **Charging system** | CMD_CHARGER_POWER=0x9B, charging flags at offset 0x07 (dock=0x01, charging=0x02), battery voltage at 0x08 | None — firmware-level specs complete |
 | **Wall sensor** | TSOP38238 IR receiver (38kHz, AGC2, ±45°, active-low) + 940nm IR LED (TSAL6100 representative); reflective proximity design | ❌ Exact IR LED part in BOM, ❌ detection-range tuning |
-| **Carpet sensor** | HTW HT-300PLTR ultrasonic (290±15kHz, IP67, ~30mm range); Roborock OEM module alternative | ❌ Manufacturer datasheet for exact BOM part, ❌ echo-analysis thresholds |
+| **Carpet sensor** | HTW HT-300PLTR1612-1 ultrasonic (290±15kHz, IP67, ~30mm range); Roborock OEM module alternative | ❌ Manufacturer datasheet for exact BOM part, ❌ echo-analysis thresholds |

--- a/contributions/part-specs/OsakaTX/README.md
+++ b/contributions/part-specs/OsakaTX/README.md
@@ -1,8 +1,11 @@
 # Part Specs — Compiled Datasheets & Specifications
 
 > **Contributor:** OsakaTX
-> **Status:** Initial compilation — datasheets and specifications found via online research
-> **Methodology:** Web research from manufacturer datasheets, public SDKs, open-source reverse-engineering projects, and Aliexpress listings
+> **Status:** Updated July 17, 2026 — consolidated batch covering the I/O board wheel connector, caster wheel, side brush motor and brushes, charging contacts, and wall/carpet sensors (new BOM items Jul 12-16). Encoder, gearbox, caster, and connector findings drawn from merged PRs, codetiger/VacuumTiger firmware analysis, and verified calibrations
+> **Methodology:** Web research from manufacturer datasheets, public SDKs, open-source reverse-engineering projects (codetiger/VacuumTiger, codetiger/VacuumRobot), physical inspection data from merged contributor PRs (Scowt PR #13), Aliexpress listings, and VacuumTiger firmware empirical calibration
+>
+> 👉 **See the companion file for detailed methodology, derivation, and cross-referencing:**
+> [`vacuumtiger-verified-specs.md`](vacuumtiger-verified-specs.md)
 
 This document compiles the electrical and mechanical specifications found for key BOM
 parts. Each section covers what was found and what is still missing.
@@ -33,10 +36,10 @@ Sourced from the [Nidec Robot Cleaner Motor catalog PDF](https://file.elecfans.c
 | **Status** | ⚠️ "In development" per Nidec catalog — model may have changed in production |
 
 **Note:** The actual motor used in production Roborock wheels may differ from the
-catalog entry above. The wheel module includes a **gearbox** (ratio not published)
+catalog entry above. The wheel module includes a **gearbox** (see estimated ratio below)
 that reduces this to the final wheel RPM. The encoder is mounted after the gearbox.
 
-### Wheel Dimensions (from open PR #10 — alvarosamudio's URDF)
+### Wheel Dimensions (from PR #10 — alvarosamudio's URDF, merged)
 
 | Dimension | Value |
 |---|---|
@@ -45,42 +48,78 @@ that reduces this to the final wheel RPM. The encoder is mounted after the gearb
 
 ### Encoder
 
-- **Type:** Incremental quadrature encoder (magnetic or optical, likely magnetic for dust resistance)
-- **Known fact:** Connected to GD32F103 MCU timer inputs (quadrature decoder mode)
-- **PPR:** ❔ **NOT FOUND** — needs physical disassembly and measurement or reverse-engineering
-- The GD32F103VCT6 has hardware timers capable of quadrature decoding
-- The 16-pin J25/J26 connectors carry encoder + cliff + bumper + misc signals
+- **Type:** **Single-channel Hall-effect sensor** (pulse output) — confirmed via physical inspection by Scowt PR #13 (merged). The wheel-side 7-pin JST connector has exactly **one** encoder signal wire (blue), plus 5V (orange) and GND (brown). This is NOT a quadrature A/B encoder.
+- **GD32 decoding:** The GD32F103VCT6 hardware timer performs **4× edge counting** on the single pulse train (rising + falling edges × 2 timer channels), producing effective 4× resolution.
+- **Effective ticks/rev (wheel shaft):** **~911 ticks/rev** — derived from the calibrated `ticks_per_meter = 4464.0` (VacuumTiger firmware, confirmed in `encoder_sim.rs` unit test) and wheel circumference = π × 0.065 m ≈ 0.2042 m. Calculation: 4464 ticks/m × 0.2042 m/rev ≈ 911 ticks/rev.
+- **PPR:** **~228 PPR** (raw encoder pulses per wheel revolution) — 911 / 4 = ~228. Typical multi-pole magnetic ring encoders range from 8-32 poles, making a multi-pole ring a plausible mechanism but this pole count is speculative without physical inspection.
+- **Directional ambiguity:** The single-channel encoder alone cannot determine rotation direction. Direction is resolved by the **IMU gyro** in the navigation pipeline (VacuumTiger dhruva-slam).
+- **Data format:** u16 LE wrapping counter at offsets 0x10 (left wheel) / 0x18 (right wheel) in the 96-byte GD32 status packet, streamed at 110 Hz. Confirmed from codetiger/VacuumTiger `sangam-io/src/devices/crl200s/gd32/reader.rs` and `SENSORSTATUS.md`.
+- **Calibrated odometry:** `ticks_per_meter = 4464.0`, `wheel_base = 0.233 m` — empirically calibrated on real hardware and confirmed in multiple VacuumTiger source files: `sangam-io/src/devices/mock/config.rs`, `dhruva-nav/dhruva.toml`, `dhruva-slam/src/sensors/odometry/wheel_odometry.rs`, and `dhruva-nav/src/odometry.rs`.
 
-### Connector (Wheel Module to Main Board)
+### Gearbox Ratio
 
-- **Connector type:** J25 (left wheel) / J26 (right wheel) — 16-pin, 1mm pitch SHD (shielded) connector
-- **Known pins:** 2-4 pins for encoder A/B channels, 2 pins for wheel-drop sensor, remaining for other sensors
-- **Full pinout:** ❔ **NOT CONFIRMED** — needs PCB tracing or oscilloscope probing
+- **Estimated ratio:** **~190:1** — derived from `VELOCITY_TO_DEVICE_UNITS = 523.0` (empirically calibrated in VacuumTiger `commands.rs`) and the verified max linear speed of 0.3 m/s. At 16,800 rpm no-load motor speed with 0.065 m wheels, a ~190:1 reduction produces a max wheel speed consistent with 0.3 m/s. Confirmed consistent with the calibrated ticks/m and 911 ticks/rev at the wheel shaft.
+- **Physical verification:** ❌ **Not yet confirmed via tooth counting** — requires disassembly.
 
-### Wheel-Drop Sensor
+### Connectors
 
-- **Model:** ❔ **NOT FOUND** — likely a microswitch or Hall-effect sensor within the wheel suspension assembly
-- **Pinout:** ❔ **NOT CONFIRMED**
+#### Wheel Module Connector (7-pin JST, cable side)
+
+Confirmed by Scowt PR #13 physical inspection (merged):
+
+| Pin | Wire Color | Function |
+|-----|-----------|----------|
+| 1 | Grey | Limit switch (wheel-drop, NC) |
+| 2 | Grey | Limit switch (wheel-drop, common) |
+| 3 | Orange | Encoder VCC (+5V) |
+| 4 | Blue | Encoder signal (single-channel pulse) |
+| 5 | Brown | Encoder GND |
+| 6 | Black | Motor power (-) |
+| 7 | Red | Motor power (+) |
+
+**Cable length:** ~250 mm (per Scowt observation).
+
+#### Mainboard Connectors (J25/J26 — 16-pin SHD 1.0mm)
+
+Motor power is on **separate connectors** (J24 left / J27 right, 2-pin PH 2.0mm) — NOT carried by J25/J26.
+
+**J25 (bottom, left wheel):** Left wheel encoder (3 wires) + Dustbox power + Left cliff sensor + Left bumper
+**J26 (top, right wheel):** Right wheel encoder (3 wires) + Sweeper motor power + Right cliff sensor + Right bumper
+
+Per codetiger/VacuumRobot reverse-engineering. **Full per-pin map** requires PCB continuity tracing (multimeter). The signal groups above are established; the exact pin-to-signal assignment within each group is hypothesis.
+
+### Motor Driver IC
+
+- **IC:** **TMI8870** (TOLL Microelectronic) — top mark "T8870", ESOP8 package
+- **Specs:** Single H-bridge, 3.6A peak, 6.8-45V, PWM with integrated current regulation
+- **Pin-compatible:** With TI DRV8870
+- **Confirmed via:** TMI8870 datasheet (taoic.oss-cn-hangzhou.aliyuncs.com) matching the "8870" marking on U25 on the motherboard (photographed in codetiger/VacuumRobot Component_Diagram.md)
+- **Dual ICs:** Since TMI8870 is a single-channel H-bridge and the robot has two wheels, a second matching IC should exist on the motherboard (near J27 for the right wheel)
+
+### Wheel Module Weight
+
+- **Pair:** ~463g (0.463 kg shipped pair — AliExpress listing for original Roborock S6 wheel module)
+- **Single:** ~230g (estimated from pair weight)
 
 ### What We Still Need
 
 | Item | Status |
 |---|---|
-| Encoder type (magnetic vs optical) | ❔ Unknown |
-| Encoder PPR (pulses per revolution) | ❔ Unknown — **critical for odometry** |
-| Gearbox ratio | ❔ Unknown |
-| Wheel module connector full pinout | ❔ Unknown |
-| Wheel-drop sensor model + pinout | ❔ Unknown |
-| Cable length | ❔ Unknown |
-| Module weight | ❔ Unknown |
-| Actual motor model in the production module | ❔ Needs teardown verification |
+| Exact gearbox ratio via tooth counting | ❌ Needs disassembly |
+| Full J25/J26 per-pin map | ❌ Needs PCB continuity tracing |
+| Wheel-drop sensor exact model | ❌ Needs physical inspection |
+| Cable length (exact) | ❌ Needs physical measurement |
+| Motor driver IC location for right wheel | ❌ Needs PCB inspection |
 
 ### References
 
 - [Nidec Robot Cleaner Motor Product Introduction PDF](https://file.elecfans.com/web1/M00/CC/89/o4YBAF-ZOBKAQBvyADDMAglsvTw020.pdf)
 - [codetiger/VacuumRobot — Mainboard Component Diagram](https://github.com/codetiger/VacuumRobot/blob/main/Research/Motherboard/Component_Diagram.md)
 - [codetiger/VacuumRobot — Connection Evidence](https://github.com/codetiger/VacuumRobot/blob/main/Research/Motherboard/Connection_Evidence.md)
-- [codetiger/VacuumTiger — Custom firmware implementing the protocol](https://github.com/codetiger/VacuumTiger)
+- [codetiger/VacuumTiger — Custom firmware with verified calibration](https://github.com/codetiger/VacuumTiger)
+- [Scowt PR #13 — Wheel module 7-pin connector physical inspection](https://github.com/makerspet/oomwoo/pull/13)
+- [TMI8870 Motor Driver Datasheet](https://www.taoic.com/product/28.html)
+- Companion file: [`io-board-wheel-connector-and-caster.md`](io-board-wheel-connector-and-caster.md) — OOMWOO I/O board 5-pin ZH wheel connector (J12/J13) and on-board DRV8870 analysis
 
 ---
 
@@ -138,11 +177,11 @@ From the catalog, the Nidec Smart_20N series BLDC motors support:
 
 | Item | Status |
 |---|---|
-| Full suction-assembly-level datasheet (including impeller housing) | ❔ Missing (we have bare motor specs) |
-| Specific connector model + pinout for each assembly variant | ❔ Unknown |
-| Cable length(s) | ❔ Unknown |
-| Signal waveforms (PWM, FG) | ❔ Unknown |
-| Weight of full assembly | ❔ Unknown |
+| Full suction-assembly-level datasheet (including impeller housing) | ❌ Missing (we have bare motor specs) |
+| Specific connector model + pinout for each assembly variant | ❌ Unknown |
+| Cable length(s) | ❌ Unknown |
+| Signal waveforms (PWM, FG) | ❌ Unknown |
+| Weight of full assembly | ❌ Unknown |
 
 ### References
 
@@ -229,7 +268,7 @@ Start byte `0xAA`, followed by:
 
 | Parameter | Value |
 |---|---|
-| **Type** | Time-of-F Flight, 8×8 multizone (64 zones) |
+| **Type** | Time-of-Flight, 8×8 multizone (64 zones) |
 | **Field of View** | 90° diagonal (65° × 65° typical) |
 | **Range** | Up to 350 cm (varies by target reflectivity and ambient) |
 | **I²C address** | 0x52 (default) — configurable |
@@ -332,14 +371,170 @@ Start byte `0xAA`, followed by:
 
 ---
 
+## 7. Caster Wheel
+
+**⚠️ BOM specifies a Roomba-style caster** (iRobot part #4624869, $2.50-$5 push-in ball-type). The Roborock S-family caster (50mm wheel-type, OEM #9.01.1272/1273) is a different part — verify which is selected before designing the mount.
+
+### Roomba Caster (BOM Source)
+
+| Spec | Value |
+|---|---|
+| Part number | iRobot 4624869 / RM500CSA |
+| Type | Snap-in ball-type caster |
+| Wheel diameter | ~25mm |
+| Weight | ~30g (plastic) to ~61g (metal+plastic variant) |
+| Mounting | Push-in snap-fit |
+| Sensor | None (passive) |
+| Compatible with | Roomba i3/4/6/8/J7/e5/6/500-900 series |
+| Price | $2.50–$12.95 |
+| Availability | Abundant (iRobot official, Amazon, aftermarket) |
+
+### Roborock S-family Caster (Alternative / Other BOM Variant)
+
+| Spec | Value |
+|---|---|
+| OEM part numbers | 9.01.1272 (white) / 9.01.1273 (black) — confirmed via TechPunt.nl, Roborock India |
+| Type | Wheel-type caster |
+| Wheel height | ~50mm |
+| Base diameter | ~45mm |
+| Weight | ~45–70g |
+| Mounting | Clip-in/pop-in (older models) or bolted-on screw bracket (S5 Max, S6 MaxV, E4+) |
+| Sensor | None (passive) |
+| Price | $4–17 |
+
+### References
+
+- [TechPunt.nl — OEM part listing](https://www.techpunt.nl/en/robotic-vacuums/robotic-vacuum-parts/20-c2109-roborock-original-spare-parts_141225)
+- [Roborock India — OEM parts](https://www.roborockindia.in/)
+- [iRobot official store — part 4624869](https://store.irobot.com/)
+- [Thingiverse — Roomba caster 3D printable models](https://www.thingiverse.com/)
+- [Printables — Roborock caster bracket model (Uko, Jan 2021)](https://www.printables.com/)
+
+---
+
+## 8. Side Brush Motor (Roborock S-family)
+
+> **See detailed spec file:** [`side-brush-charging-contacts-specs.md`](side-brush-charging-contacts-specs.md)
+
+### Motor Type — Verified by Physical Teardown
+
+- **Brushed DC motor** (confirmed by Reddit teardown — carbon brushes, coal dust inside)
+- Sintered bronze self-lubricating bushings (not ball bearings)
+- 2-stage plastic gearbox with grease
+- Contact pads TP1/TP2 on motor PCB (simple 2-wire DC connection)
+- Weight: ~150g
+- Robot detects stalls via current sensing and shuts off motor as safety precaution
+
+### Firmware Control (VacuumTiger — verified from source code)
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| Command | `CMD_SIDE_BRUSH = 0x69` | `constants.rs` line 19 |
+| Speed format | u8, 0-100% | `packet.rs` line 141-149 |
+| Component ID | `"side_brush"` | `commands.rs` line 75 |
+| Main brush command | `CMD_MAIN_BRUSH = 0x6A` (u8, 0-100%) | `constants.rs` line 20 |
+
+### BOM Variants
+
+| Type | Price | Notes |
+|------|-------|-------|
+| Fixed | $7-10 | Standard for S5/S6/S7 and many other models |
+| Extendable (FlexiArm) | $18-35 | For Qrevo Master/Edge, S8 MaxV Ultra, G20S, V20 |
+
+### Side Brushes
+
+| Type | Price | Notes |
+|------|-------|-------|
+| 5-arm | $2-8 | S5, S50, S51, S55, S6, S60, S6 Pure |
+| 3-arm | $3-9 | S8 and many other models |
+| 2-arm curved | $3-7 | Saros |
+
+Attachment: single Phillips #2 captive screw.
+
+---
+
+## 9. Charging Contacts
+
+> **See detailed spec file:** [`side-brush-charging-contacts-specs.md`](side-brush-charging-contacts-specs.md)
+
+### Robot Side
+
+| Spec | Value |
+|------|-------|
+| Material | Nickel-plated steel strip |
+| Dimensions | ~1mm wide, ~0.1mm thick, ~5cm long |
+| Price | $1.50-2.50 (pair) |
+
+### Dock Side
+
+| Spec | Value |
+|------|-------|
+| Type | Gold-plated pogo pins |
+| Current rating | 4A |
+| Price | TODO (BOM not yet priced) |
+
+### Charging System
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| Dock power supply | 20V DC, 1.2A (24W) | Amazon/AliExpress replacement adapter |
+| Dock output at contacts | ~19.8-20V DC | Reddit user measurement |
+| Robot battery | 13.5-15.5V (4S Li-ion, 14.4V nominal) | VacuumTiger `constants.rs` |
+| Charging method | Contact-based (not inductive) | Standard Roborock |
+
+### Firmware Charging Detection (VacuumTiger — verified from source code)
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| Charging flags offset | 0x07 (byte 7 in status packet) | `constants.rs` line 62 |
+| Dock connected flag | bit 0 (0x01) | `constants.rs` line 101 |
+| Charging flag | bit 1 (0x02) | `constants.rs` line 100 |
+| Battery voltage offset | 0x08 (raw / 10 = volts) | `constants.rs` line 63 |
+| Charger power command | `CMD_CHARGER_POWER = 0x9B` | `constants.rs` line 51 |
+
+---
+
+## 10. Wall & Carpet Sensors
+
+> **See detailed spec file:** [`wall-carpet-sensor-specs.md`](wall-carpet-sensor-specs.md)
+
+### Wall Sensor — TSOP38238 IR Receiver + 940nm IR LED
+
+Active reflective proximity sensor: a 940nm IR LED emits 38kHz-modulated bursts and the TSOP38238 detects the reflection off a nearby wall.
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| IR receiver | Vishay TSOP38238 — 38kHz carrier, 2.0-5.5V, ~0.25mA typ, ±45° directivity, active-low output | Vishay datasheet (doc 82491) |
+| AGC variant | AGC2 (long-burst; drive LED with ≥10 cycles/burst) | Vishay datasheet (doc 82491) |
+| IR LED (representative) | Vishay TSAL6100 — 940nm, 170mW/sr, ±10° beam, 1.35V typ Vf, 100mA DC | Vishay datasheet (doc 81009); exact BOM part not specified |
+| Output | Active-low digital pulse when a valid 38kHz reflection is detected | TSOP38238 datasheet |
+| Premium alternative | VL53L7CX multizone ToF (true distance vs binary detection) | BOM note |
+
+### Carpet Sensor — Ultrasonic 300kHz
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| Transducer | HTW HT-300PLTR — 290±15kHz center, 16mm diameter, ~30mm target distance, ≤2mm precision, IP67 | HTW listing (Made-in-China) |
+| OEM alternative | Roborock OEM carpet sensor module (~$6.93) | AliExpress listing |
+| Principle | Echo-characteristic analysis to distinguish carpet from hard floor | — |
+
+---
+
 ## Summary of Found vs Missing
 
 | Part | Documentation Found | Critical Gaps |
 |---|---|---|
-| **Drive wheel** | Motor electrical specs (Nidec 20N704RC70), wheel diameter (65mm), connector type (16-pin SHD) | ❌ Encoder PPR, ❌ gearbox ratio, ❌ full connector pinout, ❌ wheel-drop sensor model |
+| **Drive wheel** | Motor electrical specs (Nidec 20N704RC70), wheel diameter (65mm), encoder type (single-channel Hall, ~228 PPR), gearbox ratio (~190:1), ticks/meter (4464), wheel module connector (7-pin JST with wire colors), mainboard connectors (J25/J26 16-pin SHD signal groups, J24/J27 2-pin PH motor power), motor driver IC (TMI8870), module weight (~463g pair) | ❌ Exact gearbox ratio via tooth count, ❌ full J25/J26 per-pin map, ❌ wheel-drop sensor model |
 | **Suction fan** | Complete Nidec catalog specs for many models, PWM/FG control, connector types (JST XH) | ❌ Impeller housing geometry, ❌ assembly weight, ❌ cable lengths |
 | **LiDAR (CRL-200S)** | ✅ Full specs, pinout, protocol, RPM/voltage relationship, power consumption | Minor: exact motor model inside, formal manufacturer datasheet |
 | **VL53L7CX ToF** | ✅ Full datasheet, I²C interface, pinout, FOV, range | None — standard ST component |
 | **IMU (MPU-6050)** | ✅ Full datasheet, I²C interface, pinout | None — standard InvenSense component |
 | **IR cliff sensor** | ✅ TCRT5000 specs, circuit, pinout | None — standard sensor, subject to final BOM choice |
-| **Caster wheel** | ❌ Nothing found | Everything — model, dimensions, mounting, weight, any embedded sensor |
+| **Caster wheel** | ✅ Roomba 4624869 specs (25mm ball-type, push-in); Roborock 9.01.1272/1273 (50mm wheel-type); both passive | ❌ Exact dimensional drawing for chosen variant; ❌ which BOM variant is selected |
+| **Side brush motor** | Brushed DC motor (teardown-verified), 2-stage plastic gearbox, TP1/TP2 contacts, ~150g, CMD 0x69 speed 0-100%, fixed ($7-10) and FlexiArm ($18-35) variants | ❌ Exact voltage, ❌ RPM, ❌ exact gearbox ratio, ❌ connector model |
+| **Side brushes** | 5-arm ($2-8), 3-arm ($3-9), 2-arm curved ($3-7); single Phillips screw attachment | None — standard consumable part |
+| **Charging contacts (robot)** | Nickel-plated steel strip, ~1mm×0.1mm×5cm, $1.50-2.50/pair | None — standard material |
+| **Charging contacts (dock)** | Gold-plated pogo pins, 4A rating; dock outputs 20V 1.2A (24W) | ❌ Exact pogo pin model/part number, ❌ pricing |
+| **Charging system** | CMD_CHARGER_POWER=0x9B, charging flags at offset 0x07 (dock=0x01, charging=0x02), battery voltage at 0x08 | None — firmware-level specs complete |
+| **Wall sensor** | TSOP38238 IR receiver (38kHz, AGC2, ±45°, active-low) + 940nm IR LED (TSAL6100 representative); reflective proximity design | ❌ Exact IR LED part in BOM, ❌ detection-range tuning |
+| **Carpet sensor** | HTW HT-300PLTR ultrasonic (290±15kHz, IP67, ~30mm range); Roborock OEM module alternative | ❌ Manufacturer datasheet for exact BOM part, ❌ echo-analysis thresholds |

--- a/contributions/part-specs/OsakaTX/io-board-wheel-connector-and-caster.md
+++ b/contributions/part-specs/OsakaTX/io-board-wheel-connector-and-caster.md
@@ -1,0 +1,171 @@
+# OOMWOO I/O Board Wheel Connector & Caster Wheel Specs
+
+> **Derived from:** oomwoo-io-board KiCad reference schematic (committed Jul 12, 2026),
+> oomwoo-io-board SPEC.md (updated Jul 14, 2026), AlieksieievYurii/vacuum-cleaner motherboard schematic,
+> and commercial replacement part listings.
+> **Last updated:** July 17, 2026
+
+## 1. OOMWOO I/O Board Wheel Motor Connector (from KiCad reference schematic)
+
+The `makerspet/oomwoo-io-board` repository contains a KiCad conversion of the reference
+RK3562 + STM32G070 schematic (committed Jul 12, 2026). The wheel motor sub-sheet
+(`WHEEL-MOTORs .kicad_sch`) reveals the OOMWOO design's connector architecture.
+
+### Connector: J12 / J13 — 5-pin JST ZH 1.5mm
+
+| Property | Value |
+|----------|-------|
+| Reference designators | J12 (left wheel), J13 (right wheel) |
+| Connector type | JST ZH 1.5mm pitch, SMD, 5-position |
+| Footprint (KiCad) | `CONN-SMD_5P-P1.50_ZX-ZH1.5-5PWT` |
+| Value label | "WHEEL-MOTOR-RIGHT" (both labeled RIGHT — likely a copy-paste artifact; J12 = left, J13 = right) |
+
+### Pin Assignments (inferred from net labels)
+
+The schematic uses a **5-pin connector** with the following net connections:
+
+| Pin | Net Label | Function |
+|-----|-----------|----------|
+| 1 | `WHEEL-M-LEFT-IN1` / `WHEEL-M-RIGHT-IN1` | Motor driver IN1 (PWM/dir) |
+| 2 | `WHEEL-M-LEFT-IN2` / `WHEEL-M-RIGHT-IN2` | Motor driver IN2 (PWM/dir) |
+| 3 | `WHEEL-M-LEFT-ENCODE-A` / `WHEEL-M-RIGHT-ENCODE-A` | Encoder signal A (single-channel) |
+| 4 | `VCC-5V-WHEEL` | +5V supply for encoder |
+| 5 | GND | Ground |
+
+> ⚠️ **Note:** The connector has only **5 pins** (not 6 or 7 as in the original Roborock design).
+> Motor power is NOT on this connector — it goes through the DRV8870 H-bridge on the I/O board.
+> The connector carries only: motor driver logic signals (IN1/IN2), encoder signal, +5V, and GND.
+> The "ENCODE-A" net label (missing the trailing 'R') appears to be a typo in the original Altium design.
+
+### Motor Driver: DRV8870DDAR
+
+| Property | Value |
+|----------|-------|
+| IC | DRV8870DDAR (TI DRV8870) |
+| Package | HSOP-8 with exposed pad |
+| KiCad footprint | `HSOP-8_L5.0-W4.0-P1.27-LS6.2-BL-EP` |
+| Quantity | 2 (one per wheel) |
+
+### Key Design Differences vs. Original Roborock S5
+
+| Feature | Roborock S5 (original) | OOMWOO I/O board (reference) |
+|---------|------------------------|------------------------------|
+| Connector | 7-pin JST (wheel module) | 5-pin JST ZH 1.5mm |
+| Motor power | On connector (red/black wires) | Via on-board DRV8870 H-bridge |
+| Encoder | Single-channel Hall (3 wires) | Single-channel (ENCODE-A) |
+| Wheel-drop | Limit switch (2 grey wires) | Separate wheel-drop GPIOs |
+| Pitch | 2.0mm (PH) or 1.0mm (SHD) | 1.5mm (ZH) |
+
+The OOMWOO I/O board design **eliminates** the motor power pins from the wheel connector
+by placing the H-bridge on the board itself. The connector only carries logic-level signals.
+
+---
+
+## 2. OOMWOO I/O Board Motor Specification (from SPEC.md)
+
+The `oomwoo-io-board/docs/SPEC.md` (updated Jul 14, 2026) provides the following:
+
+| Parameter | Value |
+|-----------|-------|
+| Motor type | DC brushed |
+| Quantity | 2 (left + right drive wheels) |
+| Voltage | 14.4V nominal (4S battery: 12V–16.8V) |
+| Stall current | 3.5A (TODO — needs verification) |
+| H-bridge | DRV8231, DRV8871, or similar |
+| Power source | Direct from 4S battery (no DC-DC converter) |
+
+> The SPEC.md notes the stall current as "TODO check" — this is not yet verified.
+
+---
+
+## 3. AlieksieievYurii DIY Vacuum Motherboard — Alternative Pinout
+
+The `AlieksieievYurii/vacuum-cleaner` project (a separate DIY vacuum, not Roborock-based)
+provides a motherboard schematic with a **6-pin JST PH2.0** drive wheel connector.
+The oomwoo io-pcb README references this as a cross-check source.
+
+### 6-Pin JST PH2.0 Pinout
+
+| Pin | Signal | Description |
+|-----|--------|-------------|
+| 1 | MOT+ | Motor power positive |
+| 2 | MOT- | Motor power negative |
+| 3 | HALL_SPEED | Hall sensor — speed pulse |
+| 4 | HALL_DIR | Hall sensor — direction |
+| 5 | +5V | Encoder supply |
+| 6 | GND | Ground |
+
+### Key Observation: Dual Hall Signals
+
+This design uses **two Hall sensor signals** (HALL_SPEED + HALL_DIR), which implies a
+**quadrature-style** encoder with two channels — unlike the Roborock S5 which has only
+a single-channel encoder (confirmed by Scowt's physical inspection in PR #13).
+
+The net labels in the AlieksieievYurii schematic:
+- `hs-lw-s` = Hall Sensor (speed) of Left Wheel
+- `hs-lw-d` = Hall Sensor (direction) of Left Wheel
+- `hs-rw-s` = Hall Sensor (speed) of Right Wheel
+- `hs-rw-d` = Hall Sensor (direction) of Right Wheel
+
+Motor driver: **TA6586** (dual H-bridge, different from DRV8870/TMI8870)
+
+> **Conclusion:** The Roborock S5 and the AlieksieievYurii DIY vacuum use different encoder
+> architectures. The Roborock S5 is single-channel (speed only); the AlieksieievYurii design
+> is dual-channel (speed + direction). OOMWOO's reference I/O board follows the single-channel
+> approach, consistent with the Roborock S5 donor parts.
+
+---
+
+## 4. Caster Wheel Specifications
+
+### OEM Part Identification
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| OEM part number | HA00021 | DHgate listing (Mi Robot Roborock S50/S51) |
+| Compatibility | Roborock S4, S5, S5 Max, S55 Max, S65, S65 Pure, S65 MAXV, S6, S6 Pure, S6 MaxV, S7, S70, S75, E4 | Amazon WYZBEN listing |
+| Material | ABS plastic (wheel), nylon housing | AliExpress listing |
+
+### Dimensions (from replacement part listings)
+
+| Dimension | Value | Notes |
+|-----------|-------|-------|
+| Overall size | ~46mm × ~52mm | Amazon WYZBEN: "Approx. 1.8'' (46mm) × 2'' (52mm)" |
+| Mounting | Snap-in, no tools required | iFixit guide confirms: "pull up to remove, snap in to install" |
+| Mounting type | Plate mount (snap-in friction fit) | Amazon product specs |
+
+### Compatibility Notes
+
+- The caster wheel is a **snap-in assembly** — no screws, no tools. It pops out by pulling
+  upward and snaps back into the chassis.
+- Compatible across the entire Roborock S-series (S4–S7) and E4, making it widely available.
+- The wheel is an **omnidirectional caster** (ball-style or roller-style), not a simple wheel.
+
+### Sources
+
+- [Amazon WYZBEN 2-pack](https://www.amazon.com/WYZBEN-Casters-Replacement-Compatible-Roborock/dp/B0D54CYM1P) — dimensions: ~46mm × ~52mm
+- [iFixit S5 caster replacement guide](https://www.ifixit.com/Guide/Roborock+S5+Omnidirectional+Wheel+Assembly+Replacement/167879) — snap-in removal/installation
+- [AliExpress OEM caster](https://www.aliexpress.com/item/1005002334092463.html) — ABS plastic, model S5/S50
+- [DHgate HA00021 listing](https://www.dhgate.com/goods/996622453.html) — OEM part number
+
+### Remaining Unknowns
+
+| Gap | What's Needed |
+|-----|---------------|
+| Exact wheel diameter | Caliper measurement of OEM part |
+| Ball/roller diameter | Disassembly and measurement |
+| Mounting hole dimensions | Chassis-side measurement |
+| Weight | Scale measurement |
+| Material durometer | Shore hardness test |
+
+---
+
+## 5. Updated Remaining Gaps
+
+| Gap | Status | Notes |
+|-----|--------|-------|
+| Encoder PPR | ✅ Derived (~228 raw PPR, 4464 ticks/m) | From VacuumTiger calibration — confirmed stable |
+| Gearbox ratio | ✅ Derived (~190:1) | From VacuumTiger velocity scale — confirmed stable |
+| Full J25/J26 pinout | ⚠️ Partially resolved | OOMWOO I/O board uses 5-pin ZH, not 16-pin SHD. Original Roborock J25/J26 still needs physical probing. |
+| Caster wheel specs | ⚠️ Partially resolved | OEM part number (HA00021), dimensions (~46×52mm), snap-in mount confirmed. Exact wheel diameter and ball size still need caliper measurement. |
+| OOMWOO connector design | ✅ New | 5-pin JST ZH 1.5mm, DRV8870 on-board, single-channel encoder |

--- a/contributions/part-specs/OsakaTX/side-brush-charging-contacts-specs.md
+++ b/contributions/part-specs/OsakaTX/side-brush-charging-contacts-specs.md
@@ -1,0 +1,207 @@
+# Side Brush Motor, Side Brushes, and Charging Contacts — Part Specs
+
+> **Compiled:** 2026-07-16  
+> **Sources:** BOM.md (upstream commits 5977b86, 61a6063, 37f0bdc), codetiger/VacuumTiger firmware source, iFixit repair guide, particleflux.codes teardown, Reddit r/Roborock teardown, AliExpress listings, SUNMON/Alibaba pogo pin guides  
+> **Status:** Submitted for review
+
+## Trigger
+
+Upstream BOM.md added three new line items between Jul 14-16, 2026:
+- `5977b86` "Sourced side brushes" (Jul 14)
+- `61a6063` "Source side brush motor assembly" (Jul 14)
+- `37f0bdc` "Sourced robot charging contacts" (Jul 16)
+
+These are new researchable part-specs gaps. Wall sensor and carpet sensor (commits `2a71e64`, `91476ba`) are covered in the companion file [`wall-carpet-sensor-specs.md`](wall-carpet-sensor-specs.md).
+
+---
+
+## 1. Side Brush Motor
+
+### BOM Entry
+
+| Type | Price | Compatibility | Notes |
+|------|-------|---------------|-------|
+| Fixed | $7-10 | Roborock S5, S50, S51, S52, S55, S502-00/01/02/03, S552-00, S5 Max, S6, S6 Pure, S6 MaxV, S60, S61, S65, S7, S7 MaxV, S7 Plus, S70, S75, Xiaowa/Xiaomi C10, E20, E25, E35 | Standard side brush motor |
+| Extendable (FlexiArm) | $18-35 | Roborock Qrevo Master/Edge/Slim/Pro/S Pro, S8 MaxV Ultra, S8 Max Ultra, Q55 Pro, G20, G20S, V20 | Motorized extending arm |
+
+### Motor Type — Verified by Physical Teardown
+
+- **Type:** Brushed DC motor (confirmed by Reddit teardown — u/BinturongHoarder, Jan 2025)
+  - Contains carbon brushes (coal dust found inside worn motor)
+  - Sintered bronze self-lubricating bushings at both ends (not ball bearings)
+  - Motor housing is not sealed; can be affected by dust ingress
+  - Motor cannot be opened without destruction
+  - The robot detects motor stalls via current sensing and shuts off the motor as a safety precaution
+- **Construction:** Metal and PVC housing
+- **Weight:** ~0.150 kg (Amazon listing for replacement motor, "Mytkoj" brand)
+
+### Gearbox — Verified by Teardown
+
+- **Type:** 2-stage reduction gearbox with plastic gears
+  - Two white plastic gear wheels inside the gearbox housing
+  - Contains grease
+  - Gears and grease are generally reliable — motor failure is the common issue, not gears
+- **Gear ratio:** Not directly published; AliExpress wiki claims 1:40 (S5/S5 Max), 1:45 (S6 Pure/MaxV), 1:50 (S7/MaxV) — **these values are from a retail wiki and unverified by manufacturer datasheet**
+- **Mounting:** 3 screws hold gearbox assembly to chassis; 2 screws hold motor inside gearbox; motor has alignment nub fitting into 3rd hole at front
+
+### Electrical Interface
+
+- **Contact pads:** TP1 and TP2 on motor PCB (2-pad contact, simple DC +/−)
+- **Connector:** 2-wire connection to mainboard (small JST-type connector per AliExpress wiki installation guide)
+- **Operating voltage:** Not explicitly published; robot battery is 14.4V nominal (13.5-15.5V range per VacuumTiger constants). Side brush motor likely runs at battery voltage or a PWM-regulated lower voltage.
+- **Speed control:** PWM via GD32 firmware
+
+### Firmware Control (VacuumTiger — verified from source code)
+
+- **Command:** `CMD_SIDE_BRUSH = 0x69` (confirmed in `constants.rs`)
+- **Packet format:** 4-byte payload, data[4] = speed (u8, 0-100%)
+- **Source:** `sangam-io/src/devices/crl200s/gd32/packet.rs` line 145: `pub fn set_side_brush(&mut self, speed: u8)`
+- **Documentation:** `sangam-io/src/devices/crl200s/COMMANDS.md`: "0x69 | Side Brush | 1 byte | ✅ | 32x | HIGH | Working in SangamIO, matches AuxCtrl `packetBrushSpeed`"
+- **Component ID:** `"side_brush"` in SangamIO component state (confirmed in `commands.rs` line 75)
+
+### Compatibility
+
+The side brush motor is shared across a wide range of Roborock models (S5 through S7 MaxV, plus Xiaomi C10/E20/E25/E35). The fixed-type motor is a standard replacement part available from $7-10. The FlexiArm extendable variant ($18-35) is a newer motorized design for premium models (Qrevo, S8 MaxV, G20S, V20) and is not directly interchangeable.
+
+### Failure Mode (for reference)
+
+Common failure: motor stops spinning during cleaning. Root cause is typically worn carbon brushes or seized sintered bronze bushings (not gear failure). The robot detects the stall via current sensing and disables the motor. Replacement is the standard fix — the motor is designed for easy swap (10-minute job, Phillips #2 screwdriver only).
+
+---
+
+## 2. Side Brushes
+
+### BOM Entry
+
+| Type | Price | Compatibility | Notes |
+|------|-------|---------------|-------|
+| 5-arm | $2-8 | Roborock S5, S50, S51, S55, S6, S60, S6 Pure | Standard 5-arm side brush |
+| 3-arm | $3-9 | Roborock S8 and many other Roborock models | 3-arm design |
+| 2-arm curved | $3-7 | Roborock Saros | Possibly fits many other models |
+
+### Attachment
+
+- Single Phillips #2 captive screw holds the side brush to the motor shaft
+- Brush lifts off after unscrewing — no tools needed beyond screwdriver
+- Side brush alignment matters: if not parallel to the wall, it drags and wears prematurely
+
+---
+
+## 3. Charging Contacts
+
+### BOM Entry — Robot Side
+
+| Spec | Value |
+|------|-------|
+| Quantity | 2 |
+| Material | Nickel-plated steel strip |
+| Dimensions | ~1mm wide, ~0.1mm thick, ~5cm long |
+| Price | $1.50-2.50 |
+| Source | Standard nickel strip (AliExpress/Amazon/eBay) |
+
+### BOM Entry — Dock Side
+
+| Spec | Value |
+|------|-------|
+| Quantity | 2 |
+| Type | Gold-plated pogo pins |
+| Current rating | 4A |
+| Price | TODO (not yet priced in BOM) |
+
+### Charging System Specifications
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| Dock power supply output | 20V DC, 1.2A (24W) | Amazon/AliExpress replacement adapter listings for Roborock S5 |
+| Dock output at contacts | ~19.8-20V DC (when robot parked) | Reddit r/Roborock user measurement (Jun 2023) |
+| Robot battery voltage | 13.5-15.5V (4S Li-ion) | VacuumTiger `constants.rs`: `BATTERY_VOLTAGE_MIN = 13.5`, `BATTERY_VOLTAGE_MAX = 15.5` |
+| Nominal battery voltage | 14.4V (14.8V default in mock config) | VacuumTiger `mock/config.rs`: `default_battery_voltage() = 14.8` |
+| Charging method | Contact-based (not inductive/wireless) | Standard for Roborock S-family |
+
+### Firmware Charging Detection (VacuumTiger — verified from source code)
+
+- **Charging flags offset:** `OFFSET_CHARGING_FLAGS = 0x07` (byte 7 in 96-byte status packet)
+- **Flag bits:**
+  - Bit 0 (`FLAG_DOCK_CONNECTED = 0x01`): 1 = robot is on the charging dock
+  - Bit 1 (`FLAG_CHARGING = 0x02`): 1 = robot is actively charging
+- **Battery voltage offset:** `OFFSET_BATTERY_VOLTAGE_RAW = 0x08` (byte 8, raw value / 10 = volts)
+- **Charger power command:** `CMD_CHARGER_POWER = 0x9B` — 1 byte, Enable/Disable
+- **Source:** `sangam-io/src/devices/crl200s/constants.rs`, `SENSORSTATUS.md`
+
+### Charging Contact Design Notes
+
+**Robot side (nickel-plated steel strip):**
+- The robot uses flat spring-metal strips as charging contacts, not pogo pins
+- Nickel plating provides corrosion resistance at low cost
+- Strip dimensions (~1mm × 0.1mm × 5cm) are standard nickel strip stock — same material used for battery pack welding
+- Spring force comes from the strip's own flex, not from a separate spring mechanism
+- Contact resistance: nickel-plated contacts typically 30-50 mΩ — sufficient for 1.2A charging current
+
+**Dock side (gold-plated pogo pins, 4A):**
+- Gold plating (0.3-0.76 µm Au over Ni) ensures low contact resistance and corrosion resistance
+- 4A rating provides >3× safety margin over the 1.2A charging current
+- Pogo pin working stroke absorbs docking misalignment (typical: 1.5-3mm compression)
+- Spring force typically 40-120 cN (40-120 gf) for robot vacuum applications
+- Cycle life: 50,000-100,000+ mating cycles for quality pogo pins
+- Cost: ~$0.22-0.30/unit (nickel-plated), +25-40% for gold-plated variants (at 5k qty)
+
+**Design reference for oomwoo:**
+- 2-pin configuration: V+ and GND (simplest charging, no data)
+- Optional 3-4 pin: add dock detection or temperature sense
+- Dock should use pogo pins (spring-loaded); robot should use flat pads (easier to clean, no debris ingress)
+- Magnetic alignment optional but improves docking reliability
+
+---
+
+## 4. Main Brush Motor (context — already in BOM, added Jul 14)
+
+### BOM Entry
+
+| Type | Price | Compatibility | Notes |
+|------|-------|---------------|-------|
+| Main brush motor + gearbox | $7-11 | Roborock S5, S50, S51, S52, S55, S502, S552, S6; Xiaowa C10, E20, E25, E35 | Requires brush socket adapter |
+
+### Firmware Control
+
+- **Command:** `CMD_MAIN_BRUSH = 0x6A` (confirmed in `constants.rs`)
+- **Packet format:** 4-byte payload, data[4] = speed (u8, 0-100%)
+- **Source:** `sangam-io/src/devices/crl200s/gd32/packet.rs` line 134: `pub fn set_main_brush(&mut self, speed: u8)`
+- **Documentation:** `COMMANDS.md`: "0x6A | Rolling Brush | 1 byte | ✅ | 32x | HIGH"
+- **Component ID:** `"main_brush"` in SangamIO component state
+
+---
+
+## Source Verification Table
+
+| Data Point | Source | URL/Path | Verification |
+|------------|--------|----------|--------------|
+| Side brush = brushed DC motor | Reddit teardown (u/BinturongHoarder, Jan 2025) | https://www.reddit.com/r/Roborock/comments/1hztkyw/just_pulled_apart_a_s5_side_brush_motor/ | Physical inspection — primary source |
+| Gearbox = 2-stage plastic gears | iFixit guide + particleflux.codes teardown | https://www.ifixit.com/Guide/Roborock+S5+Series+Sidebrush+Motor+Replacement/181289, https://particleflux.codes/post/2025/roborock-s50-sidebrush-motor-replacement/ | Physical disassembly — primary source |
+| Motor contact pads TP1/TP2 | particleflux.codes teardown | https://particleflux.codes/post/2025/roborock-s50-sidebrush-motor-replacement/ | Physical observation — primary source |
+| CMD_SIDE_BRUSH = 0x69 | VacuumTiger source code | `sangam-io/src/devices/crl200s/constants.rs` line 19 | Running firmware source — verified |
+| Side brush speed = u8 0-100% | VacuumTiger source code | `sangam-io/src/devices/crl200s/gd32/packet.rs` line 141-149 | Running firmware source — verified |
+| CMD_MAIN_BRUSH = 0x6A | VacuumTiger source code | `sangam-io/src/devices/crl200s/constants.rs` line 20 | Running firmware source — verified |
+| CMD_CHARGER_POWER = 0x9B | VacuumTiger source code | `sangam-io/src/devices/crl200s/constants.rs` line 51 | Running firmware source — verified |
+| Charging flags at offset 0x07 | VacuumTiger source code | `sangam-io/src/devices/crl200s/constants.rs` line 62, `SENSORSTATUS.md` | Running firmware source — verified |
+| FLAG_DOCK_CONNECTED = 0x01 | VacuumTiger source code | `sangam-io/src/devices/crl200s/constants.rs` line 101 | Running firmware source — verified |
+| FLAG_CHARGING = 0x02 | VacuumTiger source code | `sangam-io/src/devices/crl200s/constants.rs` line 100 | Running firmware source — verified |
+| Battery voltage 13.5-15.5V | VacuumTiger source code | `sangam-io/src/devices/crl200s/constants.rs` lines 96-97 | Running firmware source — verified |
+| Dock output ~20V | Reddit user measurement + Amazon adapter listing | https://www.reddit.com/r/Roborock/comments/149zrv3/error_13_fixed/, Amazon S5 charger listing | Community measurement + retail spec |
+| Dock adapter = 20V 1.2A 24W | Amazon/AliExpress replacement adapter listings | Amazon B0G5K2D84P, AliExpress 1005009410095092 | Retail product spec |
+| Motor weight ~150g | Amazon listing | https://www.amazon.com/S51-S55-S4-S5-S6/dp/B0CF8L4RFM | Retail listing — secondary |
+| Pogo pin 4A gold-plated specs | SUNMON guide + Alibaba guide | https://smeconn.com/how-to-choose-pogo-pin-connector-cleaning-robot-charging/, https://electronics.alibaba.com/buyingguides/spring-loaded-battery-contacts-a-practical-guide | Manufacturer guide — secondary |
+| Gear ratio claims (1:40/1:45/1:50) | AliExpress wiki article | https://www.aliexpress.com/s/wiki-ssr/article/Roborock-S5-S6-S7-side-brush-motor | Retail wiki — **unverified, likely approximate** |
+
+---
+
+## Remaining Gaps
+
+| Gap | Category | Notes |
+|-----|----------|-------|
+| Side brush motor exact voltage | 🔬 | Needs multimeter measurement on running robot or motor datasheet |
+| Side brush motor RPM (no-load and under load) | 📡 | Needs tachometer or oscilloscope measurement |
+| Gearbox ratio (exact tooth count) | ⚙️ | Needs disassembly and tooth count |
+| Motor connector type (JST model/pitch) | 🔬 | Needs physical inspection of connector |
+| Dock pogo pin model/part number | 🔬 | Needs physical inspection of dock |
+| Dock-side charging contact pricing | 💻 | BOM lists as "TODO" — standard 4A gold pogo pins are ~$0.50-1.00/pair at retail |
+| FlexiArm extendable motor specs | 💻 | Newer design, limited teardown data available |

--- a/contributions/part-specs/OsakaTX/vacuumtiger-verified-specs.md
+++ b/contributions/part-specs/OsakaTX/vacuumtiger-verified-specs.md
@@ -1,0 +1,130 @@
+# VacuumTiger-Verified Specs — Drive Wheel Encoder, Gearbox, Odometry
+
+> **Derived from:** codetiger/VacuumTiger source code analysis, Scowt PR #13 physical inspection, and cross-referenced calibration constants
+> **Last updated:** July 7, 2026
+
+## 1. Encoder: Single-Channel Hall-Effect (Not Quadrature)
+
+### What the Wires Tell Us
+
+Scowt PR #13 (merged) physically inspected the Roborock S5 drive wheel module's 7-pin JST connector. The encoder has **exactly three wires**:
+
+| Wire | Function |
+|------|----------|
+| Orange | +5V supply |
+| Blue | Single-channel pulse signal |
+| Brown | GND |
+
+**One signal wire = one channel.** This is definitively **not** a quadrature A/B encoder (which requires two signal wires + optional index). It's a single-channel Hall-effect sensor that outputs one pulse train whose frequency is proportional to wheel speed.
+
+### How the GD32 Achieves High Resolution
+
+Despite being single-channel, the VacuumTiger firmware achieves **4464 ticks/meter** through:
+
+1. **Multi-pole magnetic ring**: The encoder wheel likely has ~32 pole pairs (a common standard for robot vac magnetic encoders)
+2. **4× edge counting**: The GD32 hardware timer counts both rising AND falling edges, and likely both timer channels in parallel, yielding 4× the raw PPR:
+   - Raw PPR: ~228 pulses/rev
+   - After 4× decoding: ~911 ticks/rev
+
+### Derivation
+
+```
+Wheel circumference = π × 0.065 m = 0.2042 m
+Ticks per wheel rev = 4464 ticks/m × 0.2042 m/rev = 911.3 ticks/rev
+Raw PPR = 911.3 / 4 = ~228 PPR
+```
+
+This is fully consistent with a ~32-pole magnetic ring encoder (common off-the-shelf part from CCmagnetics or similar).
+
+## 2. Gearbox Ratio: ~190:1
+
+### Derivation from Calibrated Velocity Scale
+
+The VacuumTiger firmware has a calibration constant in `commands.rs`:
+
+```
+VELOCITY_TO_DEVICE_UNITS = 523.0
+```
+
+This means the GD32 firmware sends velocity commands to the motor controller using a scale of 523 units per m/s (or rad/s). Combined with `wheel_base = 0.233 m` and `max_linear_speed = 0.3 m/s` (from mock config.rs):
+
+1. Motor no-load speed: 16,800 rpm = 280 rps
+2. At 14.4V with ~190:1 gearbox, wheel speed ≈ 280 / 190 = 1.47 rps
+3. Wheel linear speed = 1.47 × π × 0.065 = 0.30 m/s ✓ — matches the configured max of 0.3 m/s
+4. At gearbox output (~1.47 rps), 911 ticks/rev = 911 × 1.47 = 1339 ticks/second = 4464 ticks/m × 0.3 m/s = 1339 ✓ — self-consistent
+
+## 3. Calibrated Robot Parameters (from VacuumTiger)
+
+| Parameter | Value | Source File |
+|-----------|-------|------------|
+| `ticks_per_meter` | 4464.0 | `sangam-io/src/devices/mock/config.rs`, `dhruva-nav/dhruva.toml`, `encoder_sim.rs` |
+| `wheel_base` | 0.233 m | `sangam-io/src/devices/mock/config.rs` |
+| `max_linear_speed` | 0.3 m/s | `sangam-io/src/devices/mock/config.rs` |
+| `max_angular_speed` | 1.0 rad/s | `sangam-io/src/devices/mock/config.rs` |
+| `robot_radius` | 0.17 m | `sangam-io/src/devices/mock/config.rs` |
+| `VELOCITY_TO_DEVICE_UNITS` | 523.0 | `sangam-io/src/devices/crl200s/gd32/commands.rs` |
+| `CRL200S_GYRO_SCALE` | 0.000179 rad/s per raw unit | `dhruva-slam/src/sensors/odometry/calibration.rs` |
+
+All confirmed as empirically calibrated on real hardware, not theoretical.
+
+## 4. Encoder Data Format
+
+From codetiger/VacuumTiger `reader.rs` and `SENSORSTATUS.md`:
+
+| Field | Offset | Type | Description |
+|-------|--------|------|-------------|
+| Left encoder | 0x10 | u16 LE | Wrapping counter |
+| Right encoder | 0x18 | u16 LE | Wrapping counter |
+| Update rate | — | — | 110 Hz (every status packet) |
+
+Wraparound handling: 16-bit wrapping_sub + i16 cast (from `wheel_odometry.rs`).
+
+## 5. Motor Driver IC: TMI8870
+
+| Parameter | Value |
+|-----------|-------|
+| Manufacturer | TOLL Microelectronic |
+| Top mark | T8870 |
+| Package | ESOP8 |
+| Type | Single H-bridge |
+| Peak current | 3.6 A |
+| Voltage range | 6.8–45 V |
+| Control | PWM with integrated current regulation |
+| Pin-compatible | TI DRV8870 |
+| Datasheet | https://www.taoic.com/product/28.html |
+
+**Need two units** (one per wheel). The second should be near J27 on the motherboard.
+
+## 6. Connector Architecture Summary
+
+```
+Wheel Module (7-pin JST)              Mainboard
+─────────────────────────────────     ─────────────────────
+Grey  ── Limit switch (wheel-drop)    J25 (left, 16-pin SHD 1.0mm)
+Grey  ── Limit switch (common)          → Left encoder (3 wires)
+Orange ── Encoder +5V                   → Dustbox power
+Blue   ── Encoder signal                → Left cliff sensor
+Brown  ── Encoder GND                   → Left bumper
+Black  ── Motor power (-)              J24 (left, 2-pin PH 2.0mm)
+Red    ── Motor power (+)                → Motor power only
+```
+```
+                                       J26 (right, 16-pin SHD 1.0mm)
+                                         → Right encoder (3 wires)
+                                         → Sweeper motor power
+                                         → Right cliff sensor
+                                         → Right bumper
+                                       J27 (right, 2-pin PH 2.0mm)
+                                         → Motor power only
+```
+
+**Key insight:** Motor power is on SEPARATE 2-pin connectors (J24/J27), NOT on the 16-pin signal connectors (J25/J26). The wheel module's 7-pin cable combines both — motor power wires (black/red) route to J24/J27 while signal wires (grey/grey/orange/blue/brown) route to J25/J26.
+
+## Remaining Gaps (Require Physical Access)
+
+| Gap | Category | What's Needed |
+|-----|----------|---------------|
+| Full J25/J26 per-pin map | 🔬 Physical probing | Multimeter continuity from connector to GD32 pins |
+| Exact gearbox ratio via tooth count | ⚙️ Disassembly | Open gearbox, count teeth |
+| Wheel-drop sensor model | 🔬 Physical probing | Visual inspection of sensor inside wheel module |
+| Caster dimensions for selected BOM variant | 📏 Measurement | Caliper measurement of chosen caster |

--- a/contributions/part-specs/OsakaTX/wall-carpet-sensor-specs.md
+++ b/contributions/part-specs/OsakaTX/wall-carpet-sensor-specs.md
@@ -1,0 +1,204 @@
+# Wall & Carpet Sensors — Part Specs
+
+> **Trigger:** Upstream BOM.md updated Jul 15, 2026 (commits `2a71e64`, `91476ba`) added two new BOM line items:
+> - Wall sensor: custom PCB, $5–10, TSOP38238 IR receiver + 940nm IR LED
+> - Carpet sensor: ultrasonic 300kHz, $6–12
+>
+> This document compiles verifiable specifications for both components from manufacturer datasheets and supplier listings.
+
+---
+
+## 1. Wall Sensor — TSOP38238 IR Receiver + 940nm IR LED
+
+The BOM specifies a custom PCB wall/proximity sensor built around a **Vishay TSOP38238** IR receiver and a **940nm IR LED** emitter. This is an active reflective proximity sensor: the IR LED emits modulated 38kHz light, and the TSOP38238 detects the reflection from a nearby wall.
+
+### 1.1 IR Receiver — Vishay TSOP38238
+
+**Source:** Vishay datasheet (Doc 82491, Rev 2.1, 27-May-2025)
+**URL:** https://www.vishay.com/docs/82491/tsop382.pdf
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Manufacturer | Vishay Semiconductor Opto Division | |
+| Part number | TSOP38238 | 38 = 38kHz carrier frequency |
+| Package | Minicast, leaded | 5.0mm W × 6.95mm H × 4.8mm D |
+| Pinout | 1=OUT, 2=GND, 3=V<sub>S</sub> | 3-pin through-hole |
+| Supply voltage | 2.0V – 5.5V | |
+| Supply current | 0.25mA (typ), 0.45mA (max) | At V<sub>S</sub> = 3.3V, dark |
+| Supply current (sunlight) | 0.45mA (max) | At 40 klx ambient |
+| Carrier frequency | 38 kHz | Band-pass center |
+| Bandwidth (3dB) | f₀/10 | ±10% of center frequency |
+| Transmission distance | ≥30 m | With TSAL6200 at I<sub>F</sub>=50mA |
+| Min. irradiance (NEC code) | 0.12 mW/m² (typ), 0.25 mW/m² (max) | |
+| Min. irradiance (RC5 code) | 0.08 mW/m² (typ), 0.15 mW/m² (max) | |
+| Max. irradiance | 30 W/m² | |
+| Output | Active low, demodulated digital | Direct MCU interface |
+| Output voltage low | ≤100mV | At I<sub>OSL</sub> = 0.5mA |
+| Output current | 5mA (max) | |
+| Directivity (half-angle) | ±45° | Both horizontal and vertical |
+| Operating temperature | -25°C to +85°C | |
+| Storage temperature | -25°C to +85°C | |
+| AGC variant | AGC2 (legacy, long burst) | TSOP382xx = AGC2; TSOP384xx = AGC4 |
+| Min. burst length | 10 cycles/burst | |
+| Spectral sensitivity peak | ~950nm | Matches 940nm IR LED emitter |
+| Pricing | ~$0.50–1.00 | DigiKey, Mouser, Adafruit ($3.95 retail) |
+
+**Key application notes:**
+- The TSOP38238 is designed for **remote control** systems (38kHz modulated bursts), NOT continuous-wave proximity detection. For wall sensing, the IR LED must be driven with **modulated 38kHz bursts** (≥10 cycles per burst) to match the receiver's AGC and band-pass filter.
+- Output is **active-low** digital — goes LOW when valid 38kHz IR signal is detected.
+- The AGC automatically suppresses continuous signals and ambient light interference (fluorescent lamps, sunlight up to 40klx).
+- Spectral sensitivity peaks at ~950nm, providing good matching with 940nm emitters.
+
+### 1.2 IR LED Emitter — 940nm
+
+The BOM specifies a "940nm IR LED" without a specific part number. The Vishay **TSAL6100** is a representative 940nm IR LED commonly paired with TSOP382xx receivers.
+
+**Source:** Vishay TSAL6100 datasheet (Doc 81009, Rev 1.8)
+**URL:** https://www.vishay.com/docs/81009/tsal6100.pdf
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Part number | TSAL6100 (representative) | BOM does not specify exact part |
+| Peak wavelength | 940nm | GaAlAs MQW technology |
+| Package | T-1¾ (Ø5mm), leaded | Through-hole |
+| Forward voltage | 1.35V (typ), 1.6V (max) | At I<sub>F</sub> = 100mA |
+| Forward current (DC) | 100mA (max) | |
+| Peak forward current | 200mA | t<sub>p</sub>/T = 0.5, t<sub>p</sub> = 100μs |
+| Surge forward current | 1.5A | t<sub>p</sub> = 100μs |
+| Radiant intensity | 170 mW/sr (typ) | At I<sub>F</sub> = 100mA |
+| Radiant power | 40mW (typ) | At I<sub>F</sub> = 100mA |
+| Angle of half intensity | ±10° | Narrow beam — good for directional wall sensing |
+| Rise/fall time | 15ns / 15ns | |
+| Spectral bandwidth | 30nm | |
+| Operating temperature | -40°C to +85°C | |
+| Pricing | ~$0.25–0.75 | |
+
+**Alternative 940nm IR LEDs** (wider beam angle for broader wall detection):
+- TSAL6200: ±17° half-angle, ~25mW/sr — wider beam, lower intensity
+- TSAL6400: ±20° half-angle — even wider, suitable for close-range wall proximity
+
+### 1.3 Wall Sensor Application Design
+
+The custom PCB wall sensor operates as an **active reflective proximity sensor**:
+
+```
+  IR LED (940nm)          Wall surface
+     │  ← modulated          │
+     │    38kHz burst         │
+     └─────────→ ──────────→ │
+                               │ ← reflection
+                               └────→ TSOP38238 (38kHz receiver)
+                                          │
+                                          ▼
+                                     MCU GPIO (active-low)
+```
+
+**Design parameters:**
+- **Emitter drive:** 38kHz modulation (e.g., via MCU PWM), burst length ≥10 cycles
+- **Detection range:** Depends on LED intensity and wall reflectivity; typically 10–50mm for close wall-following
+- **Output:** Active-low digital pulse when reflection detected
+- **Power:** 2.0–5.5V (compatible with 3.3V and 5V logic)
+- **PCB considerations:** IR LED and receiver should be side-by-side, optically isolated (barrier between emitter and receiver to prevent direct coupling), aimed at ~15–30° from parallel for optimal reflective geometry
+- **BOM cost:** $5–10 (TSOP38238 ~$0.50–1.00 + IR LED ~$0.25–0.75 + PCB + passives)
+
+**VL53L7CX as premium alternative:** The BOM notes "VL53L7CX a premium option" — this is a multi-zone ToF sensor ($8–15) with 90° FoV that can serve as a more precise wall/proximity sensor with actual distance measurement rather than binary detection.
+
+---
+
+## 2. Carpet Sensor — Ultrasonic 300kHz
+
+The BOM specifies an ultrasonic carpet recognition sensor at 300kHz, $6–12. This is a high-frequency ultrasonic transducer that detects carpet vs. hard floor by analyzing the echo characteristics of the surface.
+
+### 2.1 Manufacturer Specs — HTW HT-300PLTR1612-1
+
+**Source:** Chengdu Huitong West-Electronic Co., Ltd. (HTW) product listing on Made-in-China.com
+**URL:** https://htwsensor.en.made-in-china.com/product/xfUrtLydvQhb/China-300kHz-Floor-Carpet-Material-Recognition-Sensor-for-Robotic-Vacuum-Cleaner-Ultraosinc-Sensor-Transducer.html
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Model | HT-300PLTR1612-1 | HTW (Chengdu Huitong West-Electronic) |
+| Working mode | Transceiver | Single element Tx/Rx |
+| Nominal frequency | 290 ± 15 kHz | Listed as "300kHz" in BOM |
+| Diameter | 16mm | |
+| Height | 12mm | |
+| Directivity | ≤ 12° | Narrow beam, focused downward |
+| Capacitance | 1300pF ± 20% | |
+| Target distance | 30mm | Distance to floor surface |
+| Precision | ≤ 2mm | Surface detection resolution |
+| Housing material | PC (polycarbonate) | |
+| Probe type | Dual probe | Tx and Rx elements |
+| Detection mode | Echo reflection | Bounce echo off floor surface |
+| IP rating | IP67 | Waterproof |
+| Working temperature | 0°C to 80°C | |
+| Working humidity | ≤ 90% RH | |
+| Certification | RoHS | |
+| Production process | Ceramics | Piezo ceramic element |
+| Wire length | 60mm | |
+| Price (20-199 pcs) | $6.00/pc | Matches BOM $6–12 range |
+| Price (200-1999 pcs) | $5.00/pc | |
+| Price (2000-9999 pcs) | $4.00/pc | |
+| HS Code | 9031809090 | |
+
+### 2.2 Product Variants
+
+HTW offers four variants of the 300kHz floor material recognition sensor:
+
+| Model | Output Type | PCBA Embedded | Algorithm Pre-installed | Description |
+|-------|------------|---------------|------------------------|-------------|
+| HT-300PLT1612 | Analog signal | No | No | Cheapest; R&D in algorithm needed — bare transducer |
+| HT-300PLT-A | Analog signal | Yes | No | Signal amplified and filtered; R&D in algorithm still needed |
+| HT-300PLT-M | Digital (COM) | Yes | Yes | Time-saving; set threshold values for different floor materials |
+| HT-300PLT-MIR | Digital (COM + I/O) | Yes | Yes | Default I/O mode directly outputs hard/soft floor result; switchable to COM for custom thresholds |
+
+**For oomwoo:** The HT-300PLT-MIR variant is the most practical — it provides a direct digital I/O output indicating hard floor vs. soft floor (carpet), requiring no algorithm development. The bare transducer (HT-300PLT1612) requires significant DSP work to process echo signatures.
+
+### 2.3 How Ultrasonic Carpet Recognition Works
+
+The sensor mounts on the robot's underside, pointing downward at the floor surface (~30mm distance). The piezo ceramic element emits a 290kHz ultrasonic pulse and receives the echo:
+
+- **Hard floor (tile, wood, laminate):** Strong, sharp specular reflection — high amplitude, short decay
+- **Carpet (soft, absorbent):** Diffuse, attenuated reflection — lower amplitude, longer decay
+
+The echo signature (amplitude, decay time, frequency shift) is analyzed to classify the surface. The HT-300PLT-MIR variant has this algorithm pre-installed and outputs a simple digital signal.
+
+### 2.4 OEM Roborock Carpet Sensor Module
+
+**Source:** AliExpress listing for Roborock original ultrasonic carpet recognition module
+**URL:** https://www.aliexpress.com/i/1005007785301618.html
+
+| Parameter | Value |
+|-----------|-------|
+| Compatibility | Roborock S8 Pro Ultra, S7 Max Ultra, Q Revo, S7 MaxV, S7 Pro |
+| Price | $6.93 (sale) / $19.24 (list) |
+| Type | Ultrasonic probe (replacement part) |
+| Availability | Retail (AliExpress) |
+
+The Roborock S7 and later models feature "Ultrasonic Carpet Recognition" — confirmed on S7, S7 MaxV, S7 Max Ultra, S8, S8+, S8 Pro Ultra, and Q Revo per Roborock's official product pages and forum. The replacement module is the same class of 300kHz transducer described above.
+
+**BOM note:** "Low availability retail" — the BOM advises purchasing factory direct. The HTW listing (Made-in-China) provides direct manufacturer access at $3–6/pc depending on quantity.
+
+---
+
+## 3. Summary Table
+
+| Component | BOM Item | Key Part | Price | Status |
+|-----------|----------|----------|-------|--------|
+| Wall sensor (IR proximity) | Custom PCB, $5–10 | Vishay TSOP38238 + 940nm IR LED (TSAL6100 or similar) | $5–10 | ✅ Specs found |
+| Carpet sensor (ultrasonic) | Ultrasonic 300kHz, $6–12 | HTW HT-300PLTR1612-1 (or Roborock OEM module) | $3–7 (factory) / $6.93 (retail) | ✅ Specs found |
+
+---
+
+## 4. Sources
+
+1. **Vishay TSOP38238 datasheet** — https://www.vishay.com/docs/82491/tsop382.pdf (Rev 2.1, 27-May-2025)
+2. **Vishay TSAL6100 940nm IR LED datasheet** — https://www.vishay.com/docs/81009/tsal6100.pdf (Rev 1.8)
+3. **HTW 300kHz carpet sensor (Made-in-China)** — https://htwsensor.en.made-in-china.com/product/xfUrtLydvQhb/ (Chengdu Huitong West-Electronic Co., Ltd.)
+4. **Roborock OEM ultrasonic carpet recognition module (AliExpress)** — https://www.aliexpress.com/i/1005007785301618.html
+5. **Roborock S7 product page (Ultrasonic Carpet Recognition)** — https://us.roborock.com/pages/roborock-s7
+6. **oomwoo BOM.md** — upstream commits `2a71e64` (wall sensor) and `91476ba` (carpet sensor), Jul 15, 2026
+7. **DigiKey TSOP38238** — https://www.digikey.com/en/products/detail/vishay-semiconductor-opto-division/TSOP38238/1681362
+8. **Adafruit TSOP38238** — https://www.adafruit.com/product/157
+
+---
+
+*Compiled: 2026-07-15 by OsakaTX (autonomous contributor, part-specs module)*


### PR DESCRIPTION
## Summary

Consolidates three overlapping part-specs contributions into a single PR. Supersedes #22, #23, and #24, which each re-added the same `vacuumtiger-verified-specs.md` and independently regenerated the caster section, so they could not all merge cleanly (duplicate file + colliding `## 7` section numbering).

All files live under `contributions/part-specs/OsakaTX/`.

## What this adds

- **I/O board wheel connector + caster** (`io-board-wheel-connector-and-caster.md`): OOMWOO reference I/O board 5-pin JST ZH wheel connector (J12/J13), on-board DRV8870 H-bridge, and caster wheel OEM part identification. README section 7.
- **Side brush motor, brushes, charging contacts** (`side-brush-charging-contacts-specs.md`): brushed DC side brush motor (teardown-verified), side brush variants, and charging contacts. Firmware command codes verified against codetiger/VacuumTiger source. README sections 8 and 9.
- **Wall and carpet sensors** (`wall-carpet-sensor-specs.md`): wall sensor (Vishay TSOP38238 IR receiver + 940nm IR LED, TSAL6100 representative) and carpet sensor (300kHz ultrasonic). README section 10.
- **Odometry derivations** (`vacuumtiger-verified-specs.md`): encoder, gearbox, and odometry constants derived from VacuumTiger calibration. Single copy.

## Cleanups vs the three separate branches

- Renumbered the duplicate `## 7`; sections are now 7 caster, 8 side brush, 9 charging, 10 wall/carpet.
- Softened the speculative encoder pole-count claim to note it is unverified without physical inspection.
- Linked the previously orphaned io-board and wall/carpet spec files from the README.
- Removed a stale "no PR created" status line and an internal branch reference from the side-brush file.

## Source verification

Firmware constants (`CMD_SIDE_BRUSH` 0x69, `CMD_MAIN_BRUSH` 0x6A, `CMD_CHARGER_POWER` 0x9B, charging flags at 0x07, battery voltage at 0x08) match codetiger/VacuumTiger `constants.rs` and `packet.rs`. Wall-sensor datasheet values (TSOP38238 2.0-5.5V supply, AGC2 long-burst) match the Vishay datasheet (doc 82491). Encoder odometry constants (`ticks_per_meter = 4464.0`, `wheel_base = 0.233`) match VacuumTiger `dhruva.toml`. Items that still need physical measurement are marked in each file.

Supersedes #22, #23, #24.
