### PR TITLE
part-specs: I/O board sensor/motor circuitry, S5 mainboard ICs, and GD32 protocol

### DIFF
--- a/contributions/part-specs/OsakaTX/gd32-sensor-packet-and-connectors.md
+++ b/contributions/part-specs/OsakaTX/gd32-sensor-packet-and-connectors.md
@@ -1,0 +1,125 @@
+# GD32 Sensor Status Packet — Updated Encoder & Connector Details
+
+> **Source:** codetiger/VacuumTiger SENSORSTATUS.md, constants.rs (Dec 2025 – Jan 2026)
+> **Last updated:** July 16, 2026
+
+## Purpose
+
+This file supplements `vacuumtiger-verified-specs.md` with updated information
+from the VacuumTiger project's December 2025 – January 2026 code updates. The
+encoder L/R offset assignment was corrected, and the full sensor packet layout
+is now documented.
+
+## Encoder Offset Correction (Dec 10, 2025)
+
+The VacuumTiger commit "Fix wheel encoder assignment and lidar scan wrap
+detection" (3f56cd4, Dec 10, 2025) corrected the left/right encoder offsets:
+
+| Field | Offset | Previous (wrong) | Corrected |
+|-------|--------|-------------------|-----------|
+| Left wheel encoder | 0x10–0x11 | 0x18 | **0x10** |
+| Right wheel encoder | 0x18–0x19 | 0x10 | **0x18** |
+
+> **Note:** The current offsets (left = 0x10, right = 0x18) are the corrected
+> assignment. An earlier VacuumTiger revision had the two swapped; commit 3f56cd4
+> fixed it. These match the values in the companion `vacuumtiger-verified-specs.md`.
+
+## Full Sensor Status Packet (CMD 0x15, 96-byte payload)
+
+From `SENSORSTATUS.md` (codetiger/VacuumTiger, Dec 15, 2025):
+
+```
+Packet: [0xFA 0xFB] [LEN] [0x15] [PAYLOAD 96 bytes] [CRC_H] [CRC_L]
+Total: 102 bytes
+Frequency: ~110 Hz (every ~9ms at 115200 baud)
+```
+
+### Key Offsets (from constants.rs)
+
+| Offset | Size | Field | Type |
+|--------|------|-------|------|
+| 0x01 | 1 | Bumper flags | u8 bitfield |
+| 0x03 | 1 | Cliff flags | u8 bitfield |
+| 0x04 | 1 | Dustbox flags | u8 bitfield |
+| 0x07 | 1 | Charging flags | u8 bitfield |
+| 0x08 | 1 | Battery voltage (raw÷10=volts) | u8 |
+| **0x10–0x11** | 2 | **Left wheel encoder** | **u16 LE** |
+| **0x18–0x19** | 2 | **Right wheel encoder** | **u16 LE** |
+| 0x28–0x29 | 2 | Gyro X (Yaw rate, raw) | i16 LE |
+| 0x2A–0x2B | 2 | Accel X | i16 LE |
+| 0x2C–0x2D | 2 | Gyro Y (Pitch rate, raw) | i16 LE |
+| 0x2E–0x2F | 2 | Accel Y | i16 LE |
+| 0x30–0x31 | 2 | Gyro Z (Roll rate, raw) | i16 LE |
+| 0x32–0x33 | 2 | Accel Z | i16 LE |
+| 0x34–0x35 | 2 | Tilt X (LP-filtered gravity) | i16 LE |
+| 0x36–0x37 | 2 | Tilt Y (LP-filtered gravity) | i16 LE |
+| 0x38–0x39 | 2 | Tilt Z (LP-filtered gravity) | i16 LE |
+| 0x3A–0x3B | 2 | Start button | u16 LE |
+| 0x3E–0x3F | 2 | Dock button | u16 LE |
+| 0x46 | 1 | Water tank level (0-100) | u8 |
+
+### Flag Bit Definitions
+
+**Bumper (0x01):** bit 1 = right bumper, bit 2 = left bumper
+**Cliff (0x03):** bit 0 = left side, bit 1 = left front, bit 2 = right front, bit 3 = right side
+**Charging (0x07):** bit 0 = dock connected, bit 1 = charging
+**Dustbox (0x04):** bit 2 = dustbox attached
+
+### Battery Voltage
+
+```
+BATTERY_VOLTAGE_MIN = 13.5V (0%)
+BATTERY_VOLTAGE_MAX = 15.5V (100%)
+percentage = (voltage - 13.5) / (15.5 - 13.5) * 100
+```
+
+## J25/J26 Connector Architecture (Updated)
+
+From codetiger/VacuumRobot Component_Diagram.md (Oct 2025):
+
+### J25 — Left Wheel (16-pin, 1.0mm SHD)
+
+Contains signals for:
+- Left wheel encoder (2-4 pins for A/B channels)
+- Dustbox power (2 pins)
+- Left cliff sensor (IR, 2-3 pins)
+- Left bumper sensor (1-2 pins)
+
+> Status: ❓ HYPOTHESIS — needs physical pinout analysis (pin-by-pin mapping
+> to STM32F103 GPIOs still requires multimeter continuity tracing)
+
+### J26 — Right Wheel (16-pin, 1.0mm SHD)
+
+Contains signals for:
+- Right wheel encoder (2-4 pins)
+- Sweeper (side brush) motor power (2 pins)
+- Right cliff sensor (IR, 2-3 pins)
+- Right bumper sensor (1-2 pins)
+
+> Status: ❓ HYPOTHESIS — needs physical pinout analysis
+
+### Motor Power Connectors
+
+- **J24** (left motor, 2-pin 2.0mm PH): motor power only
+- **J27** (right motor, 2-pin 2.0mm PH): motor power only
+
+## Robot Platform Clarification
+
+The VacuumTiger/VacuumRobot research documents the **3irobotix CRL-200S**, which
+uses a GD32F103VCT6 motor controller. The oomwoo BOM specifies **Roborock S5**
+drive wheel assemblies, which use an **STM32F103VCT6** motor controller (see
+`roborock-s5-mainboard-ics.md`). Both are pin-compatible Cortex-M3 MCUs, but the
+firmware protocols and mainboard layouts differ.
+
+The calibrated odometry constants (ticks_per_meter=4464, wheel_base=0.233m) are
+from the CRL-200S. The Roborock S5 may have different values — these need
+independent calibration on the Roborock platform.
+
+## Sources
+
+- VacuumTiger SENSORSTATUS.md: https://github.com/codetiger/VacuumTiger/blob/main/sangam-io/src/devices/crl200s/SENSORSTATUS.md
+- VacuumTiger constants.rs: https://github.com/codetiger/VacuumTiger/blob/main/sangam-io/src/devices/crl200s/constants.rs
+- VacuumTiger encoder fix commit (3f56cd4): https://github.com/codetiger/VacuumTiger/commit/3f56cd4bd7f0a53fde654b2a1a34788f6f079a39
+- VacuumRobot Component_Diagram.md: https://github.com/codetiger/VacuumRobot/blob/main/Research/Motherboard/Component_Diagram.md
+- VacuumTiger config.rs: https://github.com/codetiger/VacuumTiger/blob/main/sangam-io/src/devices/mock/config.rs
+- VacuumTiger dhruva.toml: https://github.com/codetiger/VacuumTiger/blob/main/dhruva-nav/dhruva.toml

--- a/contributions/part-specs/OsakaTX/gd32-sensor-packet-and-connectors.md
+++ b/contributions/part-specs/OsakaTX/gd32-sensor-packet-and-connectors.md
@@ -73,6 +73,74 @@ BATTERY_VOLTAGE_MAX = 15.5V (100%)
 percentage = (voltage - 13.5) / (15.5 - 13.5) * 100
 ```
 
+## GD32 Command Set (A33 to GD32)
+
+The 0x15 packet above is the GD32's status **response**. The command (request) side of
+the protocol is a 27-command set. All opcodes below are verified against
+codetiger/VacuumTiger `constants.rs`.
+
+### Serial Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| Port | `/dev/ttyS3` (A33 UART3) |
+| Baud | 115200, 8N1 |
+| Direction | One-way (A33 to GD32 for commands; GD32 to A33 for status) |
+| Status rate | GD32 to A33 at ~110 Hz (~9 ms) |
+| Watchdog | GD32 requires a heartbeat (CMD 0x06) every 20-50 ms or motors stop |
+| Packet format | `[0xFA 0xFB] [LEN] [CMD] [PAYLOAD] [CRC_H] [CRC_L]` |
+| CRC | 16-bit big-endian word-sum checksum |
+| Init | ~5 second wake sequence at boot |
+
+### Complete Command Table
+
+| Hex | Command | Payload | Packet | Usage |
+|-----|---------|---------|--------|-------|
+| 0x04 | MCU Sleep | none | 5 B | Put GD32 to sleep |
+| 0x05 | Wakeup Ack | none | 5 B | Acknowledge GD32 wake |
+| 0x06 | Heartbeat | none | 5 B | Keep-alive (every 20-50 ms) |
+| 0x07 | Version Request | none | 5 B | Request firmware version |
+| 0x08 | Initialize / IMU Zero | none | 5 B | Boot init (no CRC required) |
+| 0x0A | Reset Error Code | none | 5 B | Clear GD32 error flags |
+| 0x0C | Protocol Sync | 1 B (0x01) | 6 B | First cmd at boot, wakes GD32 |
+| 0x0D | Request STM32 Data | none | 5 B | Poll GD32 for extra data |
+| 0x65 | Motor Mode | 1 B | 6 B | 0x00=idle, 0x02=nav mode |
+| **0x66** | **Motor Velocity** | **8 B** | **13 B** | **Primary motion control** |
+| 0x67 | Motor Speed | 4 B | 9 B | Direct wheel speed control |
+| 0x68 | Air Pump (Vacuum) | 2 B | 7 B | Blower 0-100% |
+| 0x69 | Side Brush | 1 B | 6 B | Side brush 0-100% |
+| 0x6A | Main Brush | 1 B | 6 B | Rolling brush 0-100% |
+| 0x6B | Water Pump | 1 B | 6 B | 0=off, 100=full for mop |
+| 0x71 | Lidar PWM | 4 B | 9 B | Lidar motor 0-100% |
+| 0x78 | Cliff IR Control | 1 B | 6 B | 0=off, 1=on |
+| 0x79 | Cliff IR Direction | 1 B | 6 B | Configurable direction |
+| 0x86 | Dock IR Sensor | 1 B | 6 B | Dock detection sensor |
+| 0x8D | Button LED State | 1 B | 6 B | 19 LED modes (0-18) |
+| 0x97 | Lidar Power | 1 B | 6 B | Lidar on/off |
+| 0x99 | Main Board Power | 1 B | 6 B | A33 power on/off |
+| 0x9A | Main Board Restart | none | 5 B | Reset A33 |
+| 0x9B | Charger Power | 1 B | 6 B | Charger rail on/off |
+| 0xA1 | IMU Factory Calibrate | none | 5 B | Trigger IMU calibration |
+| 0xA2 | IMU Calibrate State | none | 5 B | Query calibration status |
+| 0xA3 | Compass Calibrate | none | 5 B | Start compass cal |
+| 0xA4 | Compass Cal State | none | 5 B | Query compass cal status |
+
+### Motor Velocity Command (0x66) Packet Structure
+
+The primary motion-control command:
+
+```
+Packet: FA FB 0C 66 [linear_vel: 4 bytes i32 LE] [angular_vel: 4 bytes i32 LE] [CRC_H CRC_L]
+```
+
+- `linear_vel` = linear velocity (m/s) x 523.0, cast to i32 LE
+- `angular_vel` = angular velocity (rad/s) x 523.0, cast to i32 LE
+
+Example, forward at 0.3 m/s straight: linear = 0.3 x 523 = 157 -> `9D 00 00 00`,
+angular = 0 -> `00 00 00 00`, packet `FA FB 0C 66 9D 00 00 00 00 00 00 00 [CRC]`.
+The 523.0 scale is the same `VELOCITY_TO_DEVICE_UNITS` constant used in the gearbox-ratio
+derivation in `vacuumtiger-verified-specs.md`.
+
 ## J25/J26 Connector Architecture (Updated)
 
 From codetiger/VacuumRobot Component_Diagram.md (Oct 2025):

--- a/contributions/part-specs/OsakaTX/io-board-sensors-and-motors-schematic.md
+++ b/contributions/part-specs/OsakaTX/io-board-sensors-and-motors-schematic.md
@@ -1,0 +1,364 @@
+# OOMWOO I/O Board Schematic — Sensor & Motor Pinout Compilation
+
+> **Source:** `makerspet/oomwoo-io-board` repository — KiCad reference schematic (committed Jul 12, 2026)
+> and `docs/SPEC.md` (updated Jul 14, 2026).
+> **Extraction date:** July 17, 2026
+> **Method:** Parsed `.kicad_sch` files for component values, hierarchical net labels, and footprint assignments.
+> **Scope:** All sensor and motor sub-sheets beyond the wheel motor sheet (which is covered separately in
+> the companion file `io-board-wheel-connector-and-caster.md`).
+
+## Summary of Findings
+
+This document compiles part numbers, connector types, and net assignments for every motor
+and sensor sub-circuit on the oomwoo I/O board reference schematic. The data is extracted
+directly from KiCad schematic files — these are the oomwoo project's own design files, not
+reverse-engineering of a commercial product.
+
+**Key discoveries:**
+- Motor driver IC confirmed as **TI DRV8870DDAR** (not TMI8870 or DRV8871)
+- Side brush and main brush use **low-side N-MOSFET switches** (AO3400), not H-bridges
+- Main fan uses **P-MOSFET high-side switch** (AO3401) with tach feedback
+- Bumper sensors are **ITR9606 photomicroswitches** (optical interrupter, not mechanical switches)
+- Dock IR sensors use **TSOP34138** IR receivers (38kHz, same family as TSOP38238)
+- LiDAR connector is 4-pin (M+, M-, RX, 5V) with low-side MOSFET motor control
+- Anti-fall (cliff) sensors are 4× analog IR (left-up, left-down, right-up, right-down)
+- Side proximity sensors use discrete IR LEDs with 2N3904 NPN PWM drivers
+
+---
+
+## 1. Motor Driver — Drive Wheels
+
+| Property | Value |
+|----------|-------|
+| IC | **DRV8870DDAR** (Texas Instruments) |
+| Package | HSOP-8 with exposed pad |
+| KiCad footprint | `HSOP-8_L5.0-W4.0-P1.27-LS6.2-BL-EP` |
+| Quantity | 2 (U14 = right wheel, U15 = left wheel) |
+| Motor voltage | BAT-VCC (14.4V nominal, 12–16.8V range) |
+| Current sense | 0.2Ω shunt resistor (R83 right, R84 left) → ADC |
+| Logic supply | VCC-3V3-P (3.3V) |
+
+### DRV8870 Pin Assignments (from KiCad symbol)
+
+| Pin | Name | Function |
+|-----|------|----------|
+| 1 | GND | Ground |
+| 2 | IN2 | Input 2 (PWM/direction) |
+| 3 | IN1 | Input 1 (PWM/direction) |
+| 4 | VREF | Current reference voltage |
+| 5 | VM | Motor supply (BAT-VCC) |
+| 6 | OUT1 | Motor output 1 |
+| 7 | ISEN | Current sense output |
+| 8 | OUT2 | Motor output 2 |
+| 9 | EP | Exposed pad (GND) |
+
+### Drive Wheel Signal Nets
+
+| Net | Direction | Function |
+|-----|-----------|----------|
+| `WHEEL-M-RIGHT-IN1` / `WHEEL-M-LEFT-IN1` | STM32 → DRV8870 | Motor direction/PWM input 1 |
+| `WHEEL-M-RIGHT-IN2` / `WHEEL-M-LEFT-IN2` | STM32 → DRV8870 | Motor direction/PWM input 2 |
+| `WHEEL-M-RIGHT-ENCODE-A` / `WHEEL-M-LEFT-ENCODE-A` | Wheel encoder → STM32 | Single-channel encoder pulse |
+| `WHEEL-M-R-F-ADC` / `WHEEL-M-L-F-ADC` | Current sense → STM32 ADC | Motor current feedback |
+| `WHEEL-M-EN-V` | STM32 → power control | Motor power enable (P-MOSFET gate) |
+| `VCC-5V-WHEEL` | Power supply | +5V for wheel encoders |
+
+> **Confirmation:** Only `ENCODE-A` exists — no `ENCODE-B`. The encoder is definitively
+> single-channel on the oomwoo reference design, matching Scowt PR #13's physical inspection
+> of the Roborock S5 wheel module (single blue encoder wire).
+
+### Additional Wheel Circuit Components
+
+| Ref | Value | Function |
+|-----|-------|----------|
+| Q12 | AO3401 | P-MOSFET — motor power enable switch |
+| Q13 | 2N3904 | NPN transistor — power control logic |
+| R83/R84 | 0.2Ω | Current sense shunt resistor |
+| D19/D20 | 1N4007 | Flyback diode (motor back-EMF protection) |
+| C85/C89 | 100µF | Bulk decoupling capacitor |
+| C86/C90 | 0.1µF | High-frequency decoupling |
+| C84/C88 | 0.22µF | Filter capacitor |
+
+---
+
+## 2. Side Brush Motors
+
+| Property | Value |
+|----------|-------|
+| Connectors | J15 (right), J16 (left) |
+| Connector value labels | "SIDE BRUSH RIGHT", "SIDE BRUSH LEFT" |
+| Motor driver | **AO3400 N-MOSFET** (low-side switch, NOT H-bridge) |
+| MOSFETs | Q16 (right), Q18 (left) |
+| Flyback diodes | D8 (right), D9 (left) — **SS34** (Schottky, 3A, 40V) |
+| Current sense | 10kΩ pull-up (R107 right, R112 left) → ADC |
+
+### Side Brush Signal Nets
+
+| Net | Function |
+|-----|----------|
+| `SIDE-BRUSH-V-R-CTRL` / `SIDE-BRUSH-V-L-CTRL` | STM32 PWM → MOSFET gate (speed control) |
+| `SIDE-BRUSH-R-F-ADC` / `SIDE-BRUSH-L-F-ADC` | Current sense → STM32 ADC |
+
+> **Design note:** Side brushes use unidirectional low-side MOSFET switches (single
+> direction only), not H-bridges. This matches the SPEC.md entry: "Side brush — bridge or
+> FET TBD." The schematic resolves this: it's a FET (low-side N-MOSFET).
+>
+> The SS34 Schottky diode (3A, 40V) is the flyback protection — rated higher than the
+> side brush stall current (1.3A per SPEC.md).
+
+---
+
+## 3. Main Brush Motor
+
+| Property | Value |
+|----------|-------|
+| Connector | J11 ("MAIN BRUSH") |
+| Motor driver | **AO3400 N-MOSFET** (low-side switch, Q10) |
+| Flyback diode | D7 — **SS34** (Schottky, 3A, 40V) |
+| Flyback diode 2 | D18 — **1N4007** (secondary protection) |
+| Current sense | 10kΩ pull-up (R82) → ADC |
+
+### Main Brush Signal Nets
+
+| Net | Function |
+|-----|----------|
+| `MAIN-BRUSH` | STM32 PWM → MOSFET gate (speed control) |
+| `MAIN-BRUSH-F-ADC` | Current sense → STM32 ADC |
+
+> **Design note:** Like the side brushes, the main brush uses a unidirectional low-side
+> MOSFET switch. SPEC.md lists stall current as "22A??" — the SS34 (3A) seems undersized
+> for 22A stall, suggesting either the stall current estimate is wrong or additional
+> protection exists. The SPEC.md TODO marker is appropriate.
+
+---
+
+## 4. Suction Fan (Main Fan)
+
+| Property | Value |
+|----------|-------|
+| Connector | J14 ("MAIN-FAN") |
+| Connector type | **4-pin PH 2.0mm** SMD (`XUNPU WAFER-PH2.0-4PWB`) |
+| Motor driver | **AO3401 P-MOSFET** (high-side switch, Q14) |
+| Control transistor | Q15 — **2N3904** NPN (drives P-MOSFET gate) |
+| Tach feedback | Yes (FG sense) |
+| Current sense | R103 (22kΩ) |
+
+### Main Fan Signal Nets
+
+| Net | Function |
+|-----|----------|
+| `MAIN-FAN-S-CTRL` | STM32 PWM → P-MOSFET gate (via NPN) — speed control |
+| `MAIN-FAN-V-CTRL` | STM32 → power enable |
+| `MAIN-FAN-S-SENSE` | Fan tachometer (FG) → STM32 |
+
+> **Design note:** The main fan uses a high-side P-MOSFET switch (AO3401) controlled via a
+> 2N3904 NPN transistor, with tachometer feedback. SPEC.md states "PWM input to fan, FG
+> feedback to STM32" — confirmed by the schematic. The 4-pin connector carries: PWM control,
+> FG sense, power (BAT-VCC), and GND.
+
+---
+
+## 5. LiDAR Motor
+
+| Property | Value |
+|----------|-------|
+| Connector | J17 ("LiDAR") |
+| Connector pins | 4 (M+, M-, RX, 5VCC — from text labels) |
+| Motor driver | **AO3400 N-MOSFET** (low-side switch, Q20) |
+| Flyback diode | D10 — **SS34** (Schottky) |
+| Current limit | R114 (2kΩ), R113 (1kΩ) |
+
+### LiDAR Signal Nets
+
+| Net | Function |
+|-----|----------|
+| `LiDAR-MOTOR-CTRL` | STM32 PWM → MOSFET gate (RPM control) |
+| `LiDAR-RXD` | LiDAR serial data → STM32 UART RX |
+
+> **Design note:** The LiDAR motor is controlled via a low-side N-MOSFET (speed via PWM),
+> with the LiDAR's serial data going to the STM32 UART. The 4-pin connector carries:
+> motor+ (always on via BAT-VCC), motor- (switched via MOSFET), serial RX, and +5V supply.
+> SPEC.md confirms: "5V 0.35A max, Mabuchi-style RF-500TB-14350 or similar, low-side load
+> switch N-FET."
+
+---
+
+## 6. Bumper & Docking IR Sensors
+
+| Property | Value |
+|----------|-------|
+| Schematic sheet | "DOCKING-IR-BUMPER-SENSORs" |
+| Bumper sensors | **2× ITR9606** (photomicroswitch / optical interrupter) |
+| Bumper references | P-SW1, P-SW2 |
+| Dock IR receivers | **2× TSOP34138** (38kHz IR receiver) |
+| Dock IR references | IR1, IR2 |
+
+### Component Details
+
+| Ref | Value | Function |
+|-----|-------|----------|
+| P-SW1 | ITR9606 | Bumper switch 1 (optical interrupter) |
+| P-SW2 | ITR9606 | Bumper switch 2 (optical interrupter) |
+| IR1 | TSOP34138 | Dock IR sensor 1 (38kHz receiver) |
+| IR2 | TSOP34138 | Dock IR sensor 2 (38kHz receiver) |
+| R61/R65 | 1kΩ | ITR9606 LED current limiting |
+| R62/R64 | 10kΩ | ITR9606 output pull-up |
+| R63/R66 | 4.7kΩ | TSOP34138 pull-up |
+
+### Signal Nets
+
+| Net | Function |
+|-----|----------|
+| `BUMPER-SW1` | Bumper 1 → STM32 digital input |
+| `BUMPER-SW2` | Bumper 2 → STM32 digital input |
+| `DOC-IR-SENS1` | Dock IR sensor 1 → STM32 |
+| `DOC-IR-SENS2` | Dock IR sensor 2 → STM32 |
+
+> **Key finding — bumper is optical, not mechanical:** The ITR9606 is a **photomicroswitch**
+> (slotted optical switch), not a mechanical microswitch. This is a non-contact bumper
+> sensor that detects physical deflection via an optical interrupter. The SPEC.md lists
+> "bumper (IR or micro-switches)" — the schematic confirms: **IR (optical interrupter)**.
+>
+> **TSOP34138 vs TSOP38238:** The dock IR sensors use TSOP34138, which is from the same
+> TSOP family as the TSOP38238 wall sensor (PR #24). The TSOP34138 operates at 38kHz
+> with a 2.0–5.5V supply, similar to the TSOP38238. The difference: TSOP34138 has shorter
+> carrier burst minimum (8 cycles vs 10+) making it more responsive for docking beacon
+> detection.
+
+---
+
+## 7. Anti-Fall (Cliff) IR Sensors
+
+| Property | Value |
+|----------|-------|
+| Schematic sheet | "ANTI-FALL-IR-SENSORs" |
+| Connectors | J4 (left-down), J5 (right-down) + implied J2/J3 (left-up, right-up) |
+| Quantity | 4 sensors (left-up, left-down, right-up, right-down) |
+| Signal type | **Analog** (ADC, not digital) |
+
+### Signal Nets
+
+| Net | Function |
+|-----|----------|
+| `ANTI-FALL-LEFT-UP-ADC` | Left-up cliff sensor → STM32 ADC |
+| `ANTI-FALL-LEFT-DOWN-ADC` | Left-down cliff sensor → STM32 ADC |
+| `ANTI-FALL-RIGHT-UP-ADC` | Right-up cliff sensor → STM32 ADC |
+| `ANTI-FALL-RIGHT-DOWN-ADC` | Right-down cliff sensor → STM32 ADC |
+
+### Components
+
+| Ref | Value | Function |
+|-----|-------|----------|
+| R67/R68/R71/R72 | 100Ω | IR LED current limiting |
+| R69/R70/R73/R74 | 10kΩ | Phototransistor output pull-up |
+
+> **Design note:** Four cliff sensors with analog output — the STM32 reads the IR
+> reflectance level via ADC, allowing threshold-based cliff detection. SPEC.md GPIO list
+> confirms: "anti-fall left up/down, right up/down (analog in because IR sensors are
+> analog)." The 100Ω LED resistor suggests ~30mA IR LED current at 3.3V (or ~50mA at 5V).
+
+---
+
+## 8. Side Proximity IR Sensors
+
+| Property | Value |
+|----------|-------|
+| Schematic sheet | "SIDE-PROXIMITY-IR-SENSOR" |
+| Connectors | J8 (left), J9 (right) |
+| IR LED drivers | **2× 2N3904** NPN transistors (Q6, Q7) for PWM |
+| Signal type | Analog (ADC) |
+
+### Signal Nets
+
+| Net | Function |
+|-----|----------|
+| `SIDE-PROXI-LEFT` | Left side proximity → STM32 ADC |
+| `SIDE-PROXI-RIGHT` | Right side proximity → STM32 ADC |
+| `TOUCHL` | Left touch/bumper → STM32 digital input |
+| `TOUCHR` | Right touch/bumper → STM32 digital input |
+
+### Components
+
+| Ref | Value | Function |
+|-----|-------|----------|
+| Q6 | 2N3904 | Left IR LED PWM driver |
+| Q7 | 2N3904 | Right IR LED PWM driver |
+| R75/R79 | 1kΩ | IR LED current limiting |
+| R76/R78 | 2kΩ | NPN base resistor |
+| R77/R80 | 1kΩ | Output pull-up |
+
+> **Design note:** Side proximity sensors use discrete IR LED + phototransistor pairs with
+> NPN transistor PWM drivers. The `TOUCHL`/`TOUCHR` nets suggest a secondary touch-sensing
+> function (possibly the same sensor at close range). SPEC.md confirms: "Side proximity IR
+> sensor left/right (analog in)" and "Side proximity IR LED left/right PWM (digital out)."
+
+---
+
+## 9. Connector Summary Table
+
+| Connector | Function | Type | Pins |
+|-----------|----------|------|------|
+| J4 | Anti-fall left-down | IR sensor | 2 |
+| J5 | Anti-fall right-down | IR sensor | 2 |
+| J8 | Side proximity left | IR sensor pair | 3–4 |
+| J9 | Side proximity right | IR sensor pair | 3–4 |
+| J11 | Main brush motor | DC motor | 2 |
+| J12 | Drive wheel right | Wheel module | 5 (JST ZH 1.5mm) |
+| J13 | Drive wheel left | Wheel module | 5 (JST ZH 1.5mm) |
+| J14 | Main fan (suction) | BLDC fan | 4 (PH 2.0mm) |
+| J15 | Side brush right | DC motor | 2 |
+| J16 | Side brush left | DC motor | 2 |
+| J17 | LiDAR | Motor + serial | 4 |
+
+---
+
+## 10. SPEC.md Motor Specifications (Cross-Reference)
+
+The `oomwoo-io-board/docs/SPEC.md` provides these motor specs (with original TODO markers):
+
+| Motor | Qty | Voltage | Stall Current | Driver | Schematic Confirms |
+|-------|-----|---------|---------------|--------|-------------------|
+| Drive wheel | 2 | 14.4V | 3.5A (TODO) | DRV8870 H-bridge | ✅ DRV8870DDAR |
+| Suction fan | 1 | 14.4V | 10A (TODO) | P-FET high-side | ✅ AO3401 |
+| LiDAR | 1 | 5V | 0.35A | N-FET low-side | ✅ AO3400 |
+| Main brush | 1 | 14.4V | 22A?? (TODO) | N-FET low-side | ✅ AO3400 |
+| Side brush | 2 | 14.4V | 1.3A (TODO) | N-FET low-side | ✅ AO3400 |
+
+> **Note:** SPEC.md originally said drive wheel H-bridge was "DRV8231, DRV8871, or similar"
+> — the KiCad schematic confirms it is specifically **DRV8870DDAR**.
+
+---
+
+## 11. Updated Remaining Gaps
+
+| Gap | Status | Notes |
+|-----|--------|-------|
+| Encoder PPR | ✅ Derived (~228 raw PPR, 4464 ticks/m) | From VacuumTiger calibration |
+| Gearbox ratio | ✅ Derived (~190:1) | From VacuumTiger velocity scale |
+| Full J25/J26 pinout | ⚠️ Partially resolved | OOMWOO I/O board uses 5-pin ZH (this doc). Original Roborock J25/J26 still needs physical probing. |
+| Caster wheel specs | ⚠️ Partially resolved | OEM part HA00021, ~46×52mm, snap-in mount (see separate file) |
+| Bumper sensor model | ✅ **NEW** | ITR9606 photomicroswitch (optical interrupter) |
+| Dock IR sensor model | ✅ **NEW** | TSOP34138 38kHz IR receiver |
+| Side brush driver | ✅ **NEW** | AO3400 N-MOSFET low-side switch (unidirectional) |
+| Main brush driver | ✅ **NEW** | AO3400 N-MOSFET low-side switch (unidirectional) |
+| Main fan driver | ✅ **NEW** | AO3401 P-MOSFET high-side switch with tach feedback |
+| LiDAR motor driver | ✅ **NEW** | AO3400 N-MOSFET low-side switch |
+| Main fan connector | ✅ **NEW** | 4-pin PH 2.0mm (XUNPU WAFER-PH2.0-4PWB) |
+| Cliff sensor type | ✅ **NEW** | 4× analog IR (ADC), 100Ω LED resistor |
+| Side proximity type | ✅ **NEW** | Discrete IR pair with 2N3904 PWM driver |
+
+---
+
+## Sources
+
+- KiCad schematic files: `https://github.com/makerspet/oomwoo-io-board/tree/main/kicad/`
+  - `WHEEL-MOTORs .kicad_sch` — drive wheel motor circuit
+  - `SIDE-BRUSH-MOTORs .kicad_sch` — side brush motor circuits
+  - `MAIN-BRUSH-MOTOR .kicad_sch` — main brush motor circuit
+  - `MAIN-FAN .kicad_sch` — suction fan circuit
+  - `LiDAR .kicad_sch` — LiDAR motor and serial circuit
+  - `DOCKING IR-BUMPER-SENSOR.kicad_sch` — bumper and dock IR sensors
+  - `ANTI-FALL-IR-SENSORs.kicad_sch` — cliff sensors
+  - `SIDE-PROXIMITY-IR-SENSOR .kicad_sch` — side proximity sensors
+- SPEC.md: `https://github.com/makerspet/oomwoo-io-board/blob/main/docs/SPEC.md`
+- GPIO budget: `https://github.com/makerspet/oomwoo-io-board/blob/main/docs/GPIO.md` (referenced in README)

--- a/contributions/part-specs/OsakaTX/roborock-s5-mainboard-ics.md
+++ b/contributions/part-specs/OsakaTX/roborock-s5-mainboard-ics.md
@@ -1,0 +1,97 @@
+# Roborock S5 Mainboard IC Identification
+
+> **Source:** feliggs/RoborockS5Hardware (GitHub), published Oct 3, 2025
+> **URL:** https://github.com/feliggs/RoborockS5Hardware
+> **Method:** Physical disassembly with adhesive removal, IC label reading
+> **License:** CC0-1.0
+> **Last updated:** July 16, 2026
+
+## Summary
+
+A physical teardown of the Roborock S5 mainboard (board mark: Ruby_S Main-B V3) was
+published by feliggs (Felix Hubenthal) in October 2025. The entire conformal adhesive
+coating was removed, exposing IC markings. This is the first publicly documented
+complete IC-level component list for the Roborock S5 mainboard.
+
+> ⚠️ **Important note on MCU identity.** The Roborock S5 mainboard uses an
+> **STM32F103VCT6** (ARM Cortex-M3, 72 MHz, 256 kB Flash) — NOT a GD32. The
+> codetiger/VacuumRobot research documented a GD32F103VCT6 on the **3irobotix
+> CRL-200S** (a different robot platform). The two robots share a similar
+> architecture (A33 SoC + Cortex-M3 motor controller) but are different products.
+> Our existing specs file (`vacuumtiger-verified-specs.md`) derives from the
+> CRL-200S; the Roborock S5 BOM part uses a different mainboard. Both the GD32 and
+> STM32F103 are pin-compatible Cortex-M3 MCUs from GigaDevice/ST, which may explain
+> the confusion.
+
+## Main Processor Architecture
+
+| Role | IC | Architecture |
+|------|----|-------------|
+| Main SoC | Allwinner R16 (marking unreadable) | Quad-core ARM Cortex-A7, Mali400MP2 |
+| Motor controller MCU | **STM32F103VCT6** | ARM Cortex-M3, 72 MHz, 256 kB Flash |
+| WiFi | Realtek RTL8189ETV (RMC 8189ET) | 2.4 GHz |
+| PMIC | X-Powers AXP223 | Power management |
+| RAM/Flash | SKhynix H5TQ4G63CFR | DDR3L + NAND |
+
+## Motor Driver ICs
+
+| # | Label | Description | Datasheet |
+|---|-------|-------------|-----------|
+| 2 | 8TI8832 | **DRV8832** Low-Voltage Motor Driver IC | [TI DRV8832](https://www.ti.com/lit/ds/symlink/drv8832.pdf) |
+| 4 | B9930 CKH0174 | Dual-N/Dual-P logic level MOSFET array (H-bridge) | [StackExchange](https://electronics.stackexchange.com/questions/550727/what-is-this-ic-b9930-ckh0174) |
+| 26 | B9930 CKH0174 | Dual-N/Dual-P logic level MOSFET array (H-bridge) | same |
+| 27 | 8870 TI 86A P3T064 | Likely **DRV8870**-class H-bridge (top mark "8870") | — |
+
+> **Correction to existing specs.** Our `vacuumtiger-verified-specs.md` section 5
+> identifies the motor driver as **TMI8870** (TOLL Microelectronic, pin-compatible
+> with TI DRV8870) based on the CRL-200S platform. On the actual Roborock S5
+> mainboard, IC #27 has the top mark "8870" with TI branding — consistent with a
+> genuine **TI DRV8870**. IC #2 is a **TI DRV8832** (low-voltage motor driver,
+> likely for the side brush or main brush). Two B9930 MOSFET arrays (#4, #26) form
+> additional H-bridges for other motors.
+
+## Battery Management
+
+| # | Label | Description | Datasheet |
+|---|-------|-------------|-----------|
+| 11 | BQ24773 TI 8AI A403 | Battery charge controller / power monitor | [TI BQ24773](https://www.ti.com/lit/ds/symlink/bq24773.pdf) |
+
+## Op-Amps and Comparators
+
+| # | Label | Type | Datasheet |
+|---|-------|------|-----------|
+| 1 | 3PEAK 1544A BBIF | Quad OpAmp | [3PEAK TP1544](https://uploadcdn.oneyac.com/attachments/files/brand/pdf/3peakit-1544a.pdf) |
+| 10 | SGM8622 XMS 1025C | OpAmp | [SGM8622](https://www.sg-micro.com/product/SGM8622) |
+| 13 | SGM8748 YMSB 1821N | Dual high-speed power comparator | [SGM8748](https://www.sg-micro.com/product/SGM8748) |
+| 20 | SGM8622E2 XMS1825C | OpAmp | same as #10 |
+| 22 | SGM8748MSB 1821N | Power comparator | same as #13 |
+| 23 | 3PEAK 1562A BBIKL | OpAmp | [3PEAK TP1562](https://www.3peak.com/low-voltage-op-amps/tp1562a) |
+| 24-25 | C3021LLD 1828 | MOSFET | [C3021LL](https://alldatasheet.net/datasheet-pdf/view-main/254492/UTC/C3021LL.html) |
+
+## Unidentified ICs
+
+| # | Label | Notes |
+|---|-------|-------|
+| 3, 5 | EKk1251 (partially readable) | Label not fully readable |
+| 6, 7 | D12 N04 CKF0577 | No public information |
+| 8 | EK0659 | No public information |
+| 9 | TI IC (type unreadable) | OpAmp (TI branded) |
+| 12 | QVH TI 87A PSHT64 | No public information |
+| 17 | (unreadable) | Label not readable |
+
+## Relevance to oomwoo BOM
+
+The Roborock S5 drive wheel assembly (BOM item) connects to this mainboard via:
+- **J25** (left, 16-pin 1.0mm SHD): encoder + cliff + bumper + dustbox signals
+- **J26** (right, 16-pin 1.0mm SHD): encoder + sweeper motor + cliff + bumper signals
+- **J24/J27** (2-pin 2.0mm PH): left/right motor power only
+
+The STM32F103VCT6 handles real-time motor PWM, encoder counting (timer inputs),
+and safety sensor (cliff/bumper) GPIO. The A33 handles WiFi, navigation, and
+high-level logic.
+
+## Sources
+
+- feliggs/RoborockS5Hardware: https://github.com/feliggs/RoborockS5Hardware (CC0-1.0)
+- Board model: Ruby_S Main-B V3 (confirmed via spare parts listing)
+- codetiger/VacuumRobot (CRL-200S, for architecture comparison): https://github.com/codetiger/VacuumRobot


### PR DESCRIPTION
## Summary

Three new hardware-reference spec files under `contributions/part-specs/OsakaTX/`. They capture deeper hardware detail the earlier part-specs work did not cover: the OOMWOO I/O board's sensor and motor-driver circuitry, an IC-level teardown of the original Roborock S5 mainboard, and the full GD32 sensor status packet.

This PR is intentionally **disjoint from #25** (which covers the wheel connector, caster, brushes/charging, wall/carpet, and encoder odometry) so both merge independently. It does not modify `README.md`, to avoid a conflict with #25; the README index entries for these files can be added once both land.

## Files

- **`io-board-sensors-and-motors-schematic.md`** — every motor and sensor sub-circuit on the `makerspet/oomwoo-io-board` KiCad reference schematic: drive-wheel driver (DRV8870DDAR), side and main brush low-side N-MOSFET switches (AO3400), main fan high-side P-MOSFET (AO3401) with tach feedback, LiDAR motor (AO3400), bumper sensors (ITR9606 optical interrupters, not mechanical switches), dock IR (TSOP34138), analog cliff and side-proximity IR sensors, and the full connector map (J4-J17).
- **`roborock-s5-mainboard-ics.md`** — IC-level teardown of the actual Roborock S5 mainboard (Ruby_S Main-B V3) from feliggs/RoborockS5Hardware (CC0-1.0): STM32F103VCT6 motor MCU, Allwinner R16 SoC, TI DRV8832 and DRV8870-class drivers, BQ24773 charge controller, and the op-amp/comparator set.
- **`gd32-sensor-packet-and-connectors.md`** — the full 96-byte GD32 sensor status packet layout (encoder, gyro/accel/tilt, buttons, water level), flag-bit definitions, the complete 27-command GD32 protocol (opcodes, serial framing, CRC, watchdog timing), and the J25/J26 connector architecture, from codetiger/VacuumTiger.

## Platform note

These sources describe three distinct reference platforms, kept clearly separate throughout:
- **OOMWOO I/O board** — STM32G070 + RK3562, wheel driver DRV8870DDAR (KiCad schematic).
- **Original Roborock S5 mainboard** — STM32F103 + TI DRV8870/DRV8832 (physical teardown).
- **3irobotix CRL-200S** — GD32F103 + TMI8870, the platform behind the VacuumTiger firmware and the odometry constants in #25.

## Source verification

- I/O board part numbers verified against the actual `makerspet/oomwoo-io-board` KiCad schematics: DRV8870 in `WHEEL-MOTORs`, ITR9606 + TSOP34138 in `DOCKING IR-BUMPER-SENSOR`, AO3400 + SS34 in the brush and LiDAR sheets, AO3401 in `MAIN-FAN`.
- Mainboard ICs verified against feliggs/RoborockS5Hardware: STM32F103, DRV8832, BQ24773, AXP223, and Allwinner R16 all appear in the teardown.
- GD32 packet offsets and flag definitions from codetiger/VacuumTiger `constants.rs` and `SENSORSTATUS.md`.

Items that still need physical measurement (exact J25/J26 per-pin map, main-brush stall current) are marked in the files.
