### PR TITLE
Add dock-cycle IR homing simulation contract

### DIFF
--- a/contributions/dock-cycle/xbattlax/README.md
+++ b/contributions/dock-cycle/xbattlax/README.md
@@ -1,0 +1,70 @@
+# Dock Cycle IR Homing Prototype by xbattlax
+
+This contribution turns the current dock-cycle RFC into a concrete, testable
+simulation contract for the first docking implementation.
+
+It focuses on the piece Gazebo does not provide out of the box: simulated IR
+homing and dock-acquisition sensors. The model is dependency-free Python so the
+geometry, line-of-sight, receiver fields of view, differential steering signal,
+and acceptance metrics can be reviewed before being embedded in a Gazebo plugin
+or ROS2 node.
+
+## What This Adds
+
+- a deterministic dock IR beacon / receiver model
+- four receiver roles matching the RFC:
+  - front-left and front-right baffled final-approach receivers
+  - left and right wider-FoV dock-search receivers
+- line-of-sight occlusion using circular blockers
+- range attenuation and receiver FoV filtering
+- a normalized final-approach steering error
+- a normalized search/acquisition steering error
+- a small JSONL scenario runner for CI-friendly traces
+- regression tests for centered approach, offset approach, side search, blockers,
+  and range attenuation
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [`tools/oomwoo_dock_ir_model.py`](tools/oomwoo_dock_ir_model.py) | Pure Python geometry and IR signal model. |
+| [`tools/sim_dock_ir_scenario.py`](tools/sim_dock_ir_scenario.py) | Deterministic JSONL scenario runner. |
+| [`tests/test_oomwoo_dock_ir_model.py`](tests/test_oomwoo_dock_ir_model.py) | Regression tests for the model. |
+| [`docs/gazebo_ir_homing_contract.md`](docs/gazebo_ir_homing_contract.md) | Proposed Gazebo logical-sensor contract. |
+| [`docs/opennav_docking_integration.md`](docs/opennav_docking_integration.md) | How this feeds Nav2 `opennav_docking`. |
+| [`docs/validation_plan.md`](docs/validation_plan.md) | Headless metrics for dock, undock, and find-dock. |
+
+## Run the Model
+
+```bash
+python3 contributions/dock-cycle/xbattlax/tools/sim_dock_ir_scenario.py
+```
+
+Example output is JSON Lines: one frame per robot pose, with receiver strengths,
+range/bearing data, selected mode, and normalized steering hint.
+
+## Test
+
+```bash
+python3 -m unittest discover \
+  -s contributions/dock-cycle/xbattlax/tests \
+  -p 'test_*.py'
+```
+
+## Intended ROS2/Gazebo Path
+
+1. Add a generic dock model to the living-room world with a beacon frame.
+2. Add four logical IR receivers to the robot URDF:
+   - `dock_ir_front_left_link`
+   - `dock_ir_front_right_link`
+   - `dock_ir_search_left_link`
+   - `dock_ir_search_right_link`
+3. Implement a small Gazebo logical sensor/plugin using the same geometry rules
+   in this prototype.
+4. Publish dock IR state for the dock-cycle controller.
+5. Use Nav2 to reach the predock pose, then use the front differential signal
+   for the final low-speed approach.
+
+This contribution deliberately does not rewrite `urdf-gazebo-sim` or the main
+dock-cycle RFC. It is a namespaced prototype that can be folded into the
+official simulation once the maintainers are happy with the contract.

--- a/contributions/dock-cycle/xbattlax/docs/gazebo_ir_homing_contract.md
+++ b/contributions/dock-cycle/xbattlax/docs/gazebo_ir_homing_contract.md
@@ -1,0 +1,70 @@
+# Gazebo IR Homing Contract
+
+Gazebo does not provide a native modulated-IR beacon/receiver sensor. This
+contract defines the small logical sensor OOMWOO needs before dock-cycle work can
+be tested headlessly.
+
+## Geometry
+
+Dock model:
+
+- `dock_base_link`: static dock root frame.
+- `dock_beacon_link`: IR emitter frame, centered on the dock face for v1.
+- `charge_contact_left` / `charge_contact_right`: contact geometry for later
+  docking success checks.
+
+Robot receiver frames:
+
+- `dock_ir_front_left_link`: baffled final-approach receiver.
+- `dock_ir_front_right_link`: baffled final-approach receiver.
+- `dock_ir_search_left_link`: wide-FoV side receiver for dock acquisition.
+- `dock_ir_search_right_link`: wide-FoV side receiver for dock acquisition.
+
+The model in `tools/oomwoo_dock_ir_model.py` assumes the front receivers are
+slightly forward and separated laterally; search receivers sit on the left/right
+sides and look outward.
+
+## Signal Rules
+
+For each receiver on each sim tick:
+
+1. Transform receiver and beacon poses into the world frame.
+2. Compute range and receiver-relative off-axis angle.
+3. Drop the signal if range exceeds `max_range_m`.
+4. Drop the signal if the beacon is outside the receiver FoV.
+5. Drop the signal if line of sight is blocked.
+6. Otherwise compute strength from range attenuation and angular gain.
+
+The prototype uses circular blockers for deterministic tests. A Gazebo plugin can
+replace this with physics ray checks against the world.
+
+## Proposed Runtime Output
+
+Initial simulation can publish JSON on a namespaced topic while message types are
+still unsettled:
+
+```text
+/oomwoo/dock/ir_state    std_msgs/msg/String
+```
+
+Fields:
+
+- `front_left`, `front_right`, `search_left`, `search_right`: strength values.
+- `front_error`: normalized left/right front differential.
+- `search_error`: normalized left/right search differential.
+- `mode`: `final_centered`, `final_turn_left`, `final_turn_right`,
+  `search_turn_left`, `search_turn_right`, or `search_pattern`.
+- `angular_z_hint`: normalized steering hint, positive left.
+
+Once stable, this should become a typed OOMWOO message package or be adapted into
+the selected `opennav_docking` plugin interface.
+
+## Failure Behavior
+
+- If all receivers are blind, publish `mode=search_pattern` and zero steering
+  hint.
+- If front receivers see the beacon, final approach owns the signal.
+- If front receivers are blind but side receivers see the beacon, search mode
+  owns the signal.
+- A stale IR frame must not keep commanding final approach. The controller should
+  require fresh frames at a fixed rate.

--- a/contributions/dock-cycle/xbattlax/docs/opennav_docking_integration.md
+++ b/contributions/dock-cycle/xbattlax/docs/opennav_docking_integration.md
@@ -1,0 +1,61 @@
+# Nav2 `opennav_docking` Integration Plan
+
+The maintainer suggested using Nav2 docking for the state machine and simulating
+IR separately. This contribution splits responsibilities that way.
+
+## State Flow
+
+1. **Predock navigation**
+   - Use Nav2 `NavigateToPose` to drive to a known predock pose in front of the
+     dock.
+   - The predock pose comes from the known dock pose when localized, or from the
+     find-dock reacquisition routine when localization failed.
+
+2. **IR acquisition**
+   - If the front receivers do not see the beacon, rotate/search using the
+     left/right search receivers until the beacon enters the front receiver FoV.
+   - If no receiver sees the beacon, use a bounded search pattern and report
+     reacquisition failure after the configured timeout.
+
+3. **Final approach**
+   - Disable normal Nav2 velocity ownership for the final low-speed approach.
+   - Use `front_error` from the IR model to steer toward zero differential.
+   - Clamp linear and angular velocity tightly.
+   - Stop immediately on bumper, cliff, wheel-drop, stale IR, or charge-contact
+     mismatch.
+
+4. **Contact confirmation**
+   - Docking succeeds only when the robot is aligned and charge contact starts.
+   - A simulated battery/charger state should later provide this confirmation.
+
+5. **Service / recharge / resume**
+   - While docked, wait for recharge or modeled station service completion.
+   - Resume the interrupted cleaning job only after the dock-cycle reports a
+     successful service result.
+
+## Controller Inputs
+
+- dock pose when known
+- Nav2 result from predock navigation
+- IR state from the logical sensor
+- battery state
+- charge-contact state
+- safety events from recovery-safety / hardware bridge
+
+## Controller Outputs
+
+- Nav2 predock goal
+- final low-speed velocity command during the final approach phase
+- dock-cycle status
+- service/recharge completion status for cleaning-jobs
+
+## Arbitration Rule
+
+Only one component should own motion at a time:
+
+- Nav2 owns motion until the predock pose succeeds.
+- dock-cycle owns low-speed motion only during final IR approach and undock.
+- recovery-safety may preempt either one on bumper/cliff/wheel-drop/e-stop.
+
+The first implementation can document this as launch/config discipline; later it
+should become an explicit command arbiter or behavior-tree contract.

--- a/contributions/dock-cycle/xbattlax/docs/validation_plan.md
+++ b/contributions/dock-cycle/xbattlax/docs/validation_plan.md
@@ -1,0 +1,68 @@
+# Dock Cycle Validation Plan
+
+This plan keeps the first dock-cycle work measurable before the full Gazebo
+plugin and robot URDF are stable.
+
+## Phase 0: Geometry Unit Tests
+
+Run:
+
+```bash
+python3 -m unittest discover \
+  -s contributions/dock-cycle/xbattlax/tests \
+  -p 'test_*.py'
+```
+
+Pass criteria:
+
+- centered predock pose gives balanced front receivers
+- lateral offset gives the correct steering direction
+- side receivers can reacquire a dock that front receivers cannot see
+- line-of-sight blockers zero the signal
+- signal attenuates with distance
+
+## Phase 1: Headless Scenario Traces
+
+Run:
+
+```bash
+python3 contributions/dock-cycle/xbattlax/tools/sim_dock_ir_scenario.py
+```
+
+Capture JSONL output as a CI artifact. Track:
+
+- mode transitions
+- front differential error
+- search differential error
+- receiver visibility
+- steering hint sign
+
+## Phase 2: Gazebo Logical Sensor
+
+Embed the same rules in a Gazebo logical sensor/plugin:
+
+- publish fresh IR frames at a fixed rate
+- compute line of sight from world geometry
+- expose receiver frames in TF/URDF
+- keep dock beacon and wall-illumination modes distinguishable
+
+Pass criteria:
+
+- 95 percent final-dock success from seeded predock poses
+- final yaw error under 5 degrees
+- lateral dock-contact error under the charge-contact tolerance selected by the
+  mechanical design
+- stale IR frames stop final approach instead of continuing motion
+
+## Phase 3: Dock-Cycle Behavior
+
+Add undock, predock navigation, final IR approach, charge confirmation, recharge,
+and resume hooks.
+
+Pass criteria:
+
+- undock reaches a known start pose
+- low battery triggers return-to-dock
+- job resumes after simulated recharge
+- find-dock recovers from seeded lost poses when the beacon is visible
+- recovery-safety preempts dock-cycle on bumper/cliff/wheel-drop/e-stop

--- a/contributions/dock-cycle/xbattlax/tests/test_oomwoo_dock_ir_model.py
+++ b/contributions/dock-cycle/xbattlax/tests/test_oomwoo_dock_ir_model.py
@@ -1,0 +1,66 @@
+import unittest
+from math import pi
+
+from pathlib import Path
+import sys
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from oomwoo_dock_ir_model import (  # noqa: E402
+    CircleObstacle,
+    DockSpec,
+    Pose2D,
+    compute_homing_frame,
+)
+
+
+class DockIrModelTest(unittest.TestCase):
+    def test_centered_final_approach_has_balanced_front_receivers(self):
+        frame = compute_homing_frame(Pose2D(1.0, 0.0, pi), DockSpec())
+
+        self.assertEqual(frame.mode, "final_centered")
+        self.assertAlmostEqual(frame.front_error, 0.0, delta=0.02)
+        self.assertGreater(frame.reading("front_left").strength, 0.0)
+        self.assertGreater(frame.reading("front_right").strength, 0.0)
+
+    def test_offset_final_approach_requests_correct_turn(self):
+        frame = compute_homing_frame(Pose2D(1.0, 0.18, pi), DockSpec())
+
+        self.assertEqual(frame.mode, "final_turn_left")
+        self.assertGreater(frame.front_error, 0.04)
+        self.assertGreater(frame.angular_z_hint, 0.0)
+
+    def test_search_receiver_detects_side_beacon_when_front_is_not_visible(self):
+        frame = compute_homing_frame(Pose2D(0.35, -1.0, pi / 2.0), DockSpec())
+
+        self.assertEqual(frame.mode, "search_turn_left")
+        self.assertEqual(frame.reading("front_left").strength, 0.0)
+        self.assertGreater(frame.reading("search_left").strength, 0.0)
+        self.assertGreater(frame.angular_z_hint, 0.0)
+
+    def test_blocker_occludes_beacon(self):
+        frame = compute_homing_frame(
+            Pose2D(1.0, 0.0, pi),
+            DockSpec(),
+            obstacles=(CircleObstacle(0.5, 0.0, 0.12),),
+        )
+
+        self.assertEqual(frame.mode, "search_pattern")
+        for reading in frame.readings:
+            self.assertFalse(reading.visible)
+            self.assertEqual(reading.strength, 0.0)
+
+    def test_signal_attenuates_with_range(self):
+        near = compute_homing_frame(Pose2D(0.75, 0.0, pi), DockSpec())
+        far = compute_homing_frame(Pose2D(1.65, 0.0, pi), DockSpec())
+
+        self.assertGreater(
+            near.reading("front_left").strength,
+            far.reading("front_left").strength,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contributions/dock-cycle/xbattlax/tools/oomwoo_dock_ir_model.py
+++ b/contributions/dock-cycle/xbattlax/tools/oomwoo_dock_ir_model.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+from math import atan2, cos, hypot, pi, sin
+from typing import Iterable
+
+
+def normalize_angle_rad(angle: float) -> float:
+    return atan2(sin(angle), cos(angle))
+
+
+def clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+@dataclass(frozen=True)
+class Pose2D:
+    x: float
+    y: float
+    yaw: float = 0.0
+
+    def transform(self, local: "Pose2D") -> "Pose2D":
+        c = cos(self.yaw)
+        s = sin(self.yaw)
+        return Pose2D(
+            self.x + c * local.x - s * local.y,
+            self.y + s * local.x + c * local.y,
+            normalize_angle_rad(self.yaw + local.yaw),
+        )
+
+
+@dataclass(frozen=True)
+class CircleObstacle:
+    x: float
+    y: float
+    radius: float
+
+
+@dataclass(frozen=True)
+class ReceiverSpec:
+    name: str
+    pose: Pose2D
+    fov_rad: float
+    max_range_m: float
+    gain: float = 1.0
+    min_range_m: float = 0.08
+    reference_range_m: float = 1.0
+    angular_exponent: float = 2.0
+
+
+@dataclass(frozen=True)
+class DockSpec:
+    pose: Pose2D = field(default_factory=lambda: Pose2D(0.0, 0.0, 0.0))
+    beacon_offset: Pose2D = field(default_factory=lambda: Pose2D(0.0, 0.0, 0.0))
+
+    @property
+    def beacon_pose(self) -> Pose2D:
+        return self.pose.transform(self.beacon_offset)
+
+
+@dataclass(frozen=True)
+class IrReading:
+    receiver: str
+    visible: bool
+    strength: float
+    range_m: float
+    bearing_in_base_rad: float
+    off_axis_rad: float
+
+
+@dataclass(frozen=True)
+class DockIrFrame:
+    mode: str
+    angular_z_hint: float
+    front_error: float
+    search_error: float
+    readings: tuple[IrReading, ...]
+
+    def reading(self, name: str) -> IrReading:
+        for item in self.readings:
+            if item.receiver == name:
+                return item
+        raise KeyError(name)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+
+DEFAULT_RECEIVERS: tuple[ReceiverSpec, ...] = (
+    ReceiverSpec(
+        "front_left",
+        Pose2D(0.16, 0.035, 0.0),
+        fov_rad=0.70,
+        max_range_m=2.0,
+        angular_exponent=8.0,
+    ),
+    ReceiverSpec(
+        "front_right",
+        Pose2D(0.16, -0.035, 0.0),
+        fov_rad=0.70,
+        max_range_m=2.0,
+        angular_exponent=8.0,
+    ),
+    ReceiverSpec(
+        "search_left",
+        Pose2D(0.00, 0.12, pi / 2.0),
+        fov_rad=3.00,
+        max_range_m=3.5,
+        gain=0.7,
+    ),
+    ReceiverSpec(
+        "search_right",
+        Pose2D(0.00, -0.12, -pi / 2.0),
+        fov_rad=3.00,
+        max_range_m=3.5,
+        gain=0.7,
+    ),
+)
+
+
+def compute_homing_frame(
+    robot_pose: Pose2D,
+    dock: DockSpec | None = None,
+    *,
+    receivers: Iterable[ReceiverSpec] = DEFAULT_RECEIVERS,
+    obstacles: Iterable[CircleObstacle] = (),
+    minimum_signal: float = 0.02,
+    centered_error: float = 0.04,
+) -> DockIrFrame:
+    dock = dock or DockSpec()
+    receiver_tuple = tuple(receivers)
+    obstacle_tuple = tuple(obstacles)
+    readings = tuple(
+        _receiver_reading(robot_pose, dock, receiver, obstacle_tuple)
+        for receiver in receiver_tuple
+    )
+
+    strengths = {reading.receiver: reading.strength for reading in readings}
+    front_left = strengths.get("front_left", 0.0)
+    front_right = strengths.get("front_right", 0.0)
+    search_left = strengths.get("search_left", 0.0)
+    search_right = strengths.get("search_right", 0.0)
+
+    front_error = _normalized_difference(front_left, front_right, minimum_signal)
+    search_error = _normalized_difference(search_left, search_right, minimum_signal)
+    front_total = front_left + front_right
+    search_total = search_left + search_right
+
+    if front_total >= minimum_signal:
+        if abs(front_error) <= centered_error:
+            mode = "final_centered"
+        elif front_error > 0.0:
+            mode = "final_turn_left"
+        else:
+            mode = "final_turn_right"
+        angular_z_hint = clamp(front_error, -1.0, 1.0)
+    elif search_total >= minimum_signal:
+        mode = "search_turn_left" if search_error > 0.0 else "search_turn_right"
+        angular_z_hint = clamp(search_error, -1.0, 1.0)
+    else:
+        mode = "search_pattern"
+        angular_z_hint = 0.0
+
+    return DockIrFrame(
+        mode=mode,
+        angular_z_hint=angular_z_hint,
+        front_error=front_error,
+        search_error=search_error,
+        readings=readings,
+    )
+
+
+def _receiver_reading(
+    robot_pose: Pose2D,
+    dock: DockSpec,
+    receiver: ReceiverSpec,
+    obstacles: tuple[CircleObstacle, ...],
+) -> IrReading:
+    receiver_world = robot_pose.transform(receiver.pose)
+    beacon_world = dock.beacon_pose
+    dx = beacon_world.x - receiver_world.x
+    dy = beacon_world.y - receiver_world.y
+    range_m = hypot(dx, dy)
+    bearing_world = atan2(dy, dx)
+    off_axis = normalize_angle_rad(bearing_world - receiver_world.yaw)
+    bearing_in_base = normalize_angle_rad(bearing_world - robot_pose.yaw)
+
+    visible = (
+        range_m <= receiver.max_range_m
+        and abs(off_axis) <= receiver.fov_rad / 2.0
+        and not _blocked(receiver_world, beacon_world, obstacles)
+    )
+    if not visible:
+        return IrReading(
+            receiver.name,
+            False,
+            0.0,
+            range_m,
+            bearing_in_base,
+            off_axis,
+        )
+
+    angular_gain = max(0.0, cos(off_axis)) ** receiver.angular_exponent
+    effective_range = max(range_m, receiver.min_range_m)
+    range_gain = min(1.0, (receiver.reference_range_m / effective_range) ** 2)
+    strength = receiver.gain * angular_gain * range_gain
+    return IrReading(
+        receiver.name,
+        True,
+        strength,
+        range_m,
+        bearing_in_base,
+        off_axis,
+    )
+
+
+def _normalized_difference(left: float, right: float, minimum_signal: float) -> float:
+    total = left + right
+    if total < minimum_signal:
+        return 0.0
+    return (left - right) / total
+
+
+def _blocked(start: Pose2D, end: Pose2D, obstacles: tuple[CircleObstacle, ...]) -> bool:
+    return any(_segment_hits_circle(start, end, obstacle) for obstacle in obstacles)
+
+
+def _segment_hits_circle(start: Pose2D, end: Pose2D, obstacle: CircleObstacle) -> bool:
+    sx = start.x
+    sy = start.y
+    ex = end.x
+    ey = end.y
+    vx = ex - sx
+    vy = ey - sy
+    length_sq = vx * vx + vy * vy
+    if length_sq == 0.0:
+        return False
+
+    t = ((obstacle.x - sx) * vx + (obstacle.y - sy) * vy) / length_sq
+    if t <= 0.0 or t >= 1.0:
+        return False
+
+    closest_x = sx + t * vx
+    closest_y = sy + t * vy
+    return hypot(closest_x - obstacle.x, closest_y - obstacle.y) <= obstacle.radius

--- a/contributions/dock-cycle/xbattlax/tools/sim_dock_ir_scenario.py
+++ b/contributions/dock-cycle/xbattlax/tools/sim_dock_ir_scenario.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+from math import pi
+from pathlib import Path
+import sys
+
+
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent))
+
+from oomwoo_dock_ir_model import (  # noqa: E402
+    CircleObstacle,
+    DockSpec,
+    Pose2D,
+    compute_homing_frame,
+)
+
+
+SCENARIOS = {
+    "centered": (
+        Pose2D(1.40, 0.00, pi),
+        Pose2D(1.00, 0.00, pi),
+        Pose2D(0.65, 0.00, pi),
+    ),
+    "offset": (
+        Pose2D(1.10, 0.18, pi),
+        Pose2D(1.00, 0.10, pi),
+        Pose2D(0.85, -0.12, pi),
+    ),
+    "search": (
+        Pose2D(0.35, 1.00, -pi / 2.0),
+        Pose2D(0.35, -1.00, pi / 2.0),
+        Pose2D(-0.80, 0.00, 0.0),
+    ),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Simulate OOMWOO dock IR frames.")
+    parser.add_argument(
+        "--scenario",
+        choices=sorted((*SCENARIOS.keys(), "blocked", "all")),
+        default="all",
+    )
+    args = parser.parse_args()
+
+    scenario_names = [*SCENARIOS, "blocked"]
+    if args.scenario != "all":
+        scenario_names = [args.scenario]
+
+    dock = DockSpec()
+    for name in scenario_names:
+        if name == "blocked":
+            poses = (Pose2D(1.0, 0.0, pi),)
+            obstacles = (CircleObstacle(0.50, 0.0, 0.12),)
+        else:
+            poses = SCENARIOS[name]
+            obstacles = ()
+
+        for index, pose in enumerate(poses):
+            frame = compute_homing_frame(pose, dock, obstacles=obstacles)
+            payload = {
+                "scenario": name,
+                "sample": index,
+                "robot_pose": asdict(pose),
+                **asdict(frame),
+            }
+            print(json.dumps(payload, sort_keys=True))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a namespaced `dock-cycle/xbattlax` prototype for the IR homing piece of the dock-cycle RFC. This follows the maintainer direction to simulate the dock beacon/receivers because Gazebo does not provide native IR sensors.

This PR adds:

- a deterministic pure-Python dock beacon / receiver geometry model
- four receiver roles from the RFC: front-left/front-right baffled final-approach receivers plus left/right wide-FoV search receivers
- line-of-sight occlusion with circular blockers
- range attenuation and receiver FoV filtering
- normalized final-approach and search steering errors
- a JSONL scenario runner for CI-friendly traces
- regression tests for centered approach, offset steering, side search, blockers, and range attenuation
- docs for the future Gazebo logical-sensor contract, Nav2 `opennav_docking` integration path, and validation metrics

## Scope

The contribution stays under `contributions/dock-cycle/xbattlax/` and deliberately does not rewrite `urdf-gazebo-sim` or the main dock-cycle RFC. The intent is to make the IR behavior reviewable and testable before folding stable pieces into the official Gazebo sim.

## Verification

- `python3 -m unittest discover -s contributions/dock-cycle/xbattlax/tests -p 'test_*.py'`
- `python3 contributions/dock-cycle/xbattlax/tools/sim_dock_ir_scenario.py --scenario blocked`
- `python3 -m py_compile contributions/dock-cycle/xbattlax/tools/oomwoo_dock_ir_model.py contributions/dock-cycle/xbattlax/tools/sim_dock_ir_scenario.py`
- `git diff --check`
