### PR TITLE
Add stack health monitor contract prototype

### DIFF
--- a/contributions/health-monitor/xbattlax/README.md
+++ b/contributions/health-monitor/xbattlax/README.md
@@ -25,11 +25,34 @@ only while the active task is fully healthy.
 
 | File | Purpose |
 |---|---|
-| [`tools/oomwoo_health_monitor.py`](tools/oomwoo_health_monitor.py) | Pure Python stack-health aggregator core. |
+| [`oomwoo_health_monitor/`](oomwoo_health_monitor/) | ROS2 package with the stack-health core and `health_monitor_node`. |
 | [`tools/sim_health_monitor.py`](tools/sim_health_monitor.py) | Deterministic JSONL scenario runner. |
 | [`tests/test_oomwoo_health_monitor.py`](tests/test_oomwoo_health_monitor.py) | Regression tests for arming, stale detection, advisory handling, and roster changes. |
+| [`tests/test_health_monitor_node_adapter.py`](tests/test_health_monitor_node_adapter.py) | ROS2 adapter tests using lightweight stubs. |
 | [`docs/stack_watchdog_contract.md`](docs/stack_watchdog_contract.md) | Detailed heartbeat, roster, aggregate, and MCU behavior contract. |
 | [`docs/recovery_safety_integration.md`](docs/recovery_safety_integration.md) | How recovery-safety should feed the monitor without relying on `/cmd_vel` timeouts. |
+
+## Package
+
+`oomwoo_health_monitor`
+
+Location:
+
+```text
+contributions/health-monitor/xbattlax/oomwoo_health_monitor
+```
+
+## Build
+
+From the OOMWOO ROS2 container:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+cd /workspace
+colcon build \
+  --base-paths contributions/health-monitor/xbattlax/oomwoo_health_monitor \
+  --packages-select oomwoo_health_monitor
+```
 
 ## Test
 
@@ -57,6 +80,28 @@ types are still unsettled:
 - `/oomwoo/health/component`
 - `/oomwoo/health/stack`
 - `/oomwoo/health/mcu_heartbeat`
+
+## Run
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 launch oomwoo_health_monitor health_monitor.launch.py
+```
+
+Publish a sample roster:
+
+```bash
+ros2 topic pub --once /oomwoo/health/roster std_msgs/msg/String \
+  "{data: '{\"task_id\":\"dock_cycle\",\"components\":[{\"component_id\":\"recovery_safety\",\"critical\":true,\"max_age_sec\":0.5}]}' }"
+```
+
+Publish a sample work-path heartbeat:
+
+```bash
+ros2 topic pub --once /oomwoo/health/component std_msgs/msg/String \
+  "{data: '{\"component_id\":\"recovery_safety\",\"health\":\"ok\",\"stamp_sec\":1.0}' }"
+```
 
 Once the contract stabilizes, these should become typed OOMWOO messages or a
 small adapter around standard diagnostics.

--- a/contributions/health-monitor/xbattlax/README.md
+++ b/contributions/health-monitor/xbattlax/README.md
@@ -1,0 +1,69 @@
+# Health Monitor Prototype by xbattlax
+
+This contribution turns the health-monitor RFC into a concrete, testable
+software-watchdog contract.
+
+It answers the follow-up from `oomwoo#33`: `/cmd_vel` holding is only one local
+freshness concern. The more general safety path is a stack health aggregator that
+checks all expected critical components and emits one MCU-facing stack heartbeat
+only while the active task is fully healthy.
+
+## What This Adds
+
+- a dependency-free health aggregator core
+- a roster contract for critical vs. advisory components
+- freshness and health-level checks for component heartbeats
+- a fail-safe arming window before MCU heartbeat emission
+- immediate heartbeat withholding on missing, stale, or unhealthy critical
+  components
+- advisory-component reporting without stopping the robot
+- a JSONL simulator for startup, stale-node, recovery, and advisory-fault traces
+- unit tests covering the deadman behavior
+- a proposed public ROS2 topic contract in `docs/SOFTWARE_INTERFACES.md`
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [`tools/oomwoo_health_monitor.py`](tools/oomwoo_health_monitor.py) | Pure Python stack-health aggregator core. |
+| [`tools/sim_health_monitor.py`](tools/sim_health_monitor.py) | Deterministic JSONL scenario runner. |
+| [`tests/test_oomwoo_health_monitor.py`](tests/test_oomwoo_health_monitor.py) | Regression tests for arming, stale detection, advisory handling, and roster changes. |
+| [`docs/stack_watchdog_contract.md`](docs/stack_watchdog_contract.md) | Detailed heartbeat, roster, aggregate, and MCU behavior contract. |
+| [`docs/recovery_safety_integration.md`](docs/recovery_safety_integration.md) | How recovery-safety should feed the monitor without relying on `/cmd_vel` timeouts. |
+
+## Test
+
+```bash
+python3 -m unittest discover \
+  -s contributions/health-monitor/xbattlax/tests \
+  -p 'test_*.py'
+```
+
+## Run the Simulator
+
+```bash
+python3 contributions/health-monitor/xbattlax/tools/sim_health_monitor.py
+```
+
+The output is JSON Lines with the current stack state, stale/missing/unhealthy
+components, advisory faults, and whether the MCU heartbeat would be emitted.
+
+## Intended ROS2 Path
+
+Initial ROS2 integration can use JSON over `std_msgs/msg/String` while message
+types are still unsettled:
+
+- `/oomwoo/health/roster`
+- `/oomwoo/health/component`
+- `/oomwoo/health/stack`
+- `/oomwoo/health/mcu_heartbeat`
+
+Once the contract stabilizes, these should become typed OOMWOO messages or a
+small adapter around standard diagnostics.
+
+## Design Rule
+
+Component heartbeats must come from the component's real work path: control
+cycle completed, scan processed, recovery decision evaluated, map update
+consumed, and so on. A free-running heartbeat timer is explicitly not enough,
+because it can keep ticking while the component's useful work loop is wedged.

--- a/contributions/health-monitor/xbattlax/docs/recovery_safety_integration.md
+++ b/contributions/health-monitor/xbattlax/docs/recovery_safety_integration.md
@@ -1,0 +1,57 @@
+# Recovery Safety Integration
+
+The recovery-safety node already sends bounded motion and explicit stops. The
+health monitor adds the more general failure path: if recovery-safety, Nav2,
+localization, or dock-cycle stops doing real work, the MCU stack heartbeat stops.
+
+## Recovery-Safety Heartbeat
+
+`recovery_safety` should publish a component heartbeat after real work events:
+
+- safety input handled
+- recovery event accepted or ignored
+- active recovery step evaluated
+- active recovery step succeeded/failed/timed out
+- status publication completed
+
+It should not publish the health heartbeat from a timer that is independent of
+the recovery controller. A timer could continue ticking while the useful recovery
+state machine is wedged.
+
+## Relationship to `/cmd_vel`
+
+The `/cmd_vel` hold fix remains useful for motion quality: recovery maneuvers
+longer than a base controller's command timeout should not be truncated.
+
+The health monitor is different. It is the robot-wide fail-safe:
+
+- if `recovery_safety` dies, MCU heartbeat stops
+- if `dock_cycle` dies during final approach, MCU heartbeat stops
+- if `localization` is stale during navigation, MCU heartbeat stops
+- if an advisory logger dies, the stack reports it but the robot keeps moving
+
+## Proposed Critical Rosters
+
+Mapping:
+
+- `recovery_safety`
+- `nav2_controller`
+- `localization`
+- `slam_toolbox` or map/localization equivalent
+
+Known-map navigation:
+
+- `recovery_safety`
+- `nav2_controller`
+- `localization`
+- `map_server`
+
+Dock final approach:
+
+- `recovery_safety`
+- `dock_cycle`
+- `dock_ir_sensor`
+- `health_monitor`
+
+The exact roster should be owned by the task launch files once those packages
+exist.

--- a/contributions/health-monitor/xbattlax/docs/stack_watchdog_contract.md
+++ b/contributions/health-monitor/xbattlax/docs/stack_watchdog_contract.md
@@ -1,0 +1,105 @@
+# Stack Watchdog Contract
+
+The health monitor is the software deadman between ROS2 and the MCU. It does not
+replace the MCU's hard reflexes; it decides whether the ROS2 stack is healthy
+enough for the MCU to keep accepting commanded motion.
+
+## Component Heartbeat
+
+Topic:
+
+```text
+/oomwoo/health/component    std_msgs/msg/String
+```
+
+Temporary JSON fields:
+
+- `component_id`: stable component id, for example `recovery_safety`.
+- `health`: `ok`, `healthy`, `warn`, `degraded`, or `error`.
+- `stamp_sec`: component work timestamp.
+- `sequence`: optional monotonic sequence.
+- `detail`: optional short diagnostic text.
+
+Rule: publish this from the work path, not from a free-running timer. Examples:
+
+- recovery-safety evaluated a safety/recovery cycle
+- Nav2 controller produced a command decision
+- localization consumed a scan and produced a pose update
+- dock-cycle evaluated a fresh IR/dock state
+
+## Roster
+
+Topic:
+
+```text
+/oomwoo/health/roster    std_msgs/msg/String
+```
+
+QoS expectation:
+
+- `transient_local`
+- reliable
+- re-published on task transitions
+
+Temporary JSON fields:
+
+- `task_id`: active task or mode, for example `cleaning_job`.
+- `components`: list of expected components.
+- each component has `component_id`, `critical`, and `max_age_sec`.
+
+Critical components block MCU heartbeat if missing, stale, or unhealthy.
+Advisory components appear in status but do not stop the robot.
+
+## Aggregated Stack State
+
+Topic:
+
+```text
+/oomwoo/health/stack    std_msgs/msg/String
+```
+
+Temporary JSON fields:
+
+- `state`: `no_roster`, `arming`, `healthy`, `healthy_with_advisory_faults`, or
+  `fault`.
+- `task_id`: current roster task.
+- `emit_mcu_heartbeat`: whether the MCU-facing heartbeat should be emitted.
+- `missing_critical`, `stale_critical`, `unhealthy_critical`.
+- `advisory_faults`.
+- `healthy_for_sec`.
+- `source`.
+
+## MCU Heartbeat
+
+Topic:
+
+```text
+/oomwoo/health/mcu_heartbeat    std_msgs/msg/String
+```
+
+The MCU-facing bridge should forward this as the stack watchdog heartbeat only
+while `emit_mcu_heartbeat=true`.
+
+Fail-safe rules:
+
+- no roster: withhold heartbeat
+- arming window not satisfied: withhold heartbeat
+- missing critical component: withhold heartbeat
+- stale critical component: withhold heartbeat
+- unhealthy critical component: withhold heartbeat
+- advisory component fault: report but keep heartbeat
+
+The MCU should soft-stop motors on a short heartbeat miss and assert CPU reset
+only on a sustained miss, matching the architecture draft.
+
+## Timing Budget
+
+Choose component freshness so:
+
+```text
+component work period < component max_age < MCU soft-stop timeout < CPU reset timeout
+```
+
+At vacuum speeds, sub-second detection keeps the travel distance small. The
+exact values should be validated under sim-clock jitter and Raspberry Pi load,
+because too-tight watchdogs produce false trips.

--- a/contributions/health-monitor/xbattlax/docs/stack_watchdog_contract.md
+++ b/contributions/health-monitor/xbattlax/docs/stack_watchdog_contract.md
@@ -92,6 +92,11 @@ Fail-safe rules:
 The MCU should soft-stop motors on a short heartbeat miss and assert CPU reset
 only on a sustained miss, matching the architecture draft.
 
+The first ROS2 adapter in this contribution is
+`oomwoo_health_monitor.health_monitor_node`. It consumes the JSON roster and
+component heartbeat topics, publishes stack state every 50 ms, and publishes the
+MCU heartbeat only while the aggregate state allows it.
+
 ## Timing Budget
 
 Choose component freshness so:

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/launch/health_monitor.launch.py
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/launch/health_monitor.launch.py
@@ -1,0 +1,15 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="oomwoo_health_monitor",
+                executable="health_monitor_node",
+                name="health_monitor",
+                output="screen",
+            )
+        ]
+    )

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/__init__.py
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/__init__.py
@@ -1,0 +1,1 @@
+"""OOMWOO stack health monitor prototype package."""

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/core.py
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 import json
 from typing import Iterable
 

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/health_monitor_node.py
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/health_monitor_node.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+from time import monotonic
+
+import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.exceptions import ROSInterruptException
+from rclpy.node import Node
+from std_msgs.msg import String
+
+from oomwoo_health_monitor.core import (
+    ComponentHeartbeat,
+    ComponentSpec,
+    HealthAggregator,
+    HealthRoster,
+)
+
+
+class HealthMonitorNode(Node):
+    def __init__(self):
+        super().__init__("health_monitor")
+        self._aggregator = HealthAggregator(arm_window_sec=0.25)
+        self._heartbeat_sequence = 0
+
+        self._stack_pub = self.create_publisher(String, "oomwoo/health/stack", 10)
+        self._mcu_pub = self.create_publisher(String, "oomwoo/health/mcu_heartbeat", 10)
+
+        self.create_subscription(String, "oomwoo/health/roster", self._roster_cb, 10)
+        self.create_subscription(String, "oomwoo/health/component", self._component_cb, 10)
+        self.create_timer(0.05, self._timer_cb)
+
+    def _roster_cb(self, msg: String):
+        try:
+            self._aggregator.update_roster(_parse_roster(json.loads(msg.data)))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            self.get_logger().warn(f"Ignoring invalid health roster: {exc}")
+
+    def _component_cb(self, msg: String):
+        try:
+            self._aggregator.update_heartbeat(_parse_heartbeat(json.loads(msg.data)))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            self.get_logger().warn(f"Ignoring invalid component heartbeat: {exc}")
+
+    def _timer_cb(self):
+        now_sec = self._now_sec()
+        stack_health = self._aggregator.evaluate(now_sec)
+        self._stack_pub.publish(String(data=stack_health.to_json()))
+        if not stack_health.emit_mcu_heartbeat:
+            return
+
+        self._heartbeat_sequence += 1
+        payload = {
+            "sequence": self._heartbeat_sequence,
+            "source": "oomwoo_health_monitor",
+            "stamp_sec": now_sec,
+            "stack": asdict(stack_health),
+            "task_id": stack_health.task_id,
+        }
+        self._mcu_pub.publish(String(data=json.dumps(payload, sort_keys=True)))
+
+    def _now_sec(self) -> float:
+        try:
+            return self.get_clock().now().nanoseconds / 1_000_000_000.0
+        except Exception:
+            return monotonic()
+
+
+def _parse_roster(payload: dict) -> HealthRoster:
+    components = []
+    for item in payload["components"]:
+        components.append(
+            ComponentSpec(
+                component_id=str(item["component_id"]),
+                critical=bool(item.get("critical", True)),
+                max_age_sec=float(item.get("max_age_sec", 0.5)),
+            )
+        )
+    return HealthRoster.from_components(str(payload["task_id"]), components)
+
+
+def _parse_heartbeat(payload: dict) -> ComponentHeartbeat:
+    return ComponentHeartbeat(
+        component_id=str(payload["component_id"]),
+        health=str(payload.get("health", "ok")),
+        stamp_sec=float(payload["stamp_sec"]),
+        detail=str(payload.get("detail", "")),
+        sequence=payload.get("sequence"),
+    )
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = HealthMonitorNode()
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException, ROSInterruptException):
+        pass
+    except Exception as exc:
+        if "context is not valid" not in str(exc):
+            raise
+    finally:
+        node.destroy_node()
+        try:
+            if rclpy.ok():
+                rclpy.shutdown()
+        except Exception as exc:
+            if "rcl_shutdown already called" not in str(exc):
+                raise

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/package.xml
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>oomwoo_health_monitor</name>
+  <version>0.1.0</version>
+  <description>Stack health monitor and MCU software watchdog prototype for OOMWOO.</description>
+  <maintainer email="xbattlax@gmail.com">xbattlax</maintainer>
+  <license>Apache-2.0</license>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/resource/oomwoo_health_monitor
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/resource/oomwoo_health_monitor
@@ -1,0 +1,1 @@
+oomwoo_health_monitor

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/setup.cfg
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/oomwoo_health_monitor
+[install]
+install_scripts=$base/lib/oomwoo_health_monitor

--- a/contributions/health-monitor/xbattlax/oomwoo_health_monitor/setup.py
+++ b/contributions/health-monitor/xbattlax/oomwoo_health_monitor/setup.py
@@ -1,0 +1,27 @@
+from setuptools import find_packages, setup
+
+
+package_name = "oomwoo_health_monitor"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+        ("share/" + package_name + "/launch", ["launch/health_monitor.launch.py"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="xbattlax",
+    maintainer_email="xbattlax@gmail.com",
+    description="Stack health monitor and MCU software watchdog prototype for OOMWOO.",
+    license="Apache-2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "health_monitor_node = oomwoo_health_monitor.health_monitor_node:main",
+        ],
+    },
+)

--- a/contributions/health-monitor/xbattlax/tests/test_health_monitor_node_adapter.py
+++ b/contributions/health-monitor/xbattlax/tests/test_health_monitor_node_adapter.py
@@ -1,0 +1,227 @@
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "oomwoo_health_monitor"
+sys.path.insert(0, str(PACKAGE_ROOT))
+
+
+class _String:
+    def __init__(self, data=""):
+        self.data = data
+
+
+class _Publisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg)
+
+
+class _Logger:
+    def __init__(self):
+        self.warnings = []
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+
+class _Time:
+    def __init__(self, seconds):
+        self.nanoseconds = int(seconds * 1_000_000_000)
+
+
+class _Clock:
+    def __init__(self, node):
+        self._node = node
+
+    def now(self):
+        return _Time(self._node.clock_sec)
+
+
+class _Node:
+    def __init__(self, name):
+        self.name = name
+        self.clock_sec = 0.0
+        self.publishers = {}
+        self.subscriptions = []
+        self.timers = []
+        self.logger = _Logger()
+
+    def create_publisher(self, _msg_type, topic, _qos):
+        publisher = _Publisher()
+        self.publishers[topic] = publisher
+        return publisher
+
+    def create_subscription(self, msg_type, topic, callback, qos):
+        self.subscriptions.append((msg_type, topic, callback, qos))
+
+    def create_timer(self, period_sec, callback):
+        self.timers.append((period_sec, callback))
+
+    def get_clock(self):
+        return _Clock(self)
+
+    def get_logger(self):
+        return self.logger
+
+    def destroy_node(self):
+        pass
+
+
+class _ExternalShutdownException(Exception):
+    pass
+
+
+class _ROSInterruptException(Exception):
+    pass
+
+
+def _ros_stubs():
+    rclpy = types.ModuleType("rclpy")
+    rclpy.init = lambda args=None: None
+    rclpy.spin = lambda node: None
+    rclpy.ok = lambda: False
+    rclpy.shutdown = lambda: None
+
+    rclpy_executors = types.ModuleType("rclpy.executors")
+    rclpy_executors.ExternalShutdownException = _ExternalShutdownException
+
+    rclpy_exceptions = types.ModuleType("rclpy.exceptions")
+    rclpy_exceptions.ROSInterruptException = _ROSInterruptException
+
+    rclpy_node = types.ModuleType("rclpy.node")
+    rclpy_node.Node = _Node
+
+    std_msgs = types.ModuleType("std_msgs")
+    std_msgs_msg = types.ModuleType("std_msgs.msg")
+    std_msgs_msg.String = _String
+
+    return {
+        "rclpy": rclpy,
+        "rclpy.executors": rclpy_executors,
+        "rclpy.exceptions": rclpy_exceptions,
+        "rclpy.node": rclpy_node,
+        "std_msgs": std_msgs,
+        "std_msgs.msg": std_msgs_msg,
+    }
+
+
+class HealthMonitorNodeAdapterTest(unittest.TestCase):
+    def setUp(self):
+        self._module_patch = mock.patch.dict(sys.modules, _ros_stubs())
+        self._module_patch.start()
+        sys.modules.pop("oomwoo_health_monitor.health_monitor_node", None)
+
+    def tearDown(self):
+        self._module_patch.stop()
+        sys.modules.pop("oomwoo_health_monitor.health_monitor_node", None)
+
+    def test_node_publishes_stack_state_and_mcu_heartbeat_after_arming(self):
+        from oomwoo_health_monitor.health_monitor_node import HealthMonitorNode
+
+        node = HealthMonitorNode()
+        node.clock_sec = 10.0
+        node._roster_cb(
+            _String(
+                data=json.dumps(
+                    {
+                        "task_id": "dock_cycle",
+                        "components": [
+                            {
+                                "component_id": "recovery_safety",
+                                "critical": True,
+                                "max_age_sec": 1.0,
+                            }
+                        ],
+                    }
+                )
+            )
+        )
+        node._component_cb(
+            _String(
+                data=json.dumps(
+                    {
+                        "component_id": "recovery_safety",
+                        "health": "ok",
+                        "stamp_sec": 10.0,
+                    }
+                )
+            )
+        )
+
+        node._timer_cb()
+        node.clock_sec = 10.3
+        node._timer_cb()
+
+        stack_messages = node.publishers["oomwoo/health/stack"].messages
+        mcu_messages = node.publishers["oomwoo/health/mcu_heartbeat"].messages
+        self.assertEqual(json.loads(stack_messages[0].data)["state"], "arming")
+        self.assertEqual(json.loads(stack_messages[-1].data)["state"], "healthy")
+        self.assertEqual(len(mcu_messages), 1)
+        self.assertEqual(json.loads(mcu_messages[0].data)["task_id"], "dock_cycle")
+
+    def test_stale_critical_component_stops_mcu_heartbeat(self):
+        from oomwoo_health_monitor.health_monitor_node import HealthMonitorNode
+
+        node = HealthMonitorNode()
+        node.clock_sec = 20.0
+        node._roster_cb(
+            _String(
+                data=json.dumps(
+                    {
+                        "task_id": "cleaning_job",
+                        "components": [
+                            {
+                                "component_id": "nav2_controller",
+                                "critical": True,
+                                "max_age_sec": 1.0,
+                            }
+                        ],
+                    }
+                )
+            )
+        )
+        node._component_cb(
+            _String(
+                data=json.dumps(
+                    {
+                        "component_id": "nav2_controller",
+                        "health": "ok",
+                        "stamp_sec": 20.0,
+                    }
+                )
+            )
+        )
+
+        node.clock_sec = 20.3
+        node._timer_cb()
+        node.clock_sec = 20.6
+        node._timer_cb()
+        node.clock_sec = 21.2
+        node._timer_cb()
+
+        stack_messages = node.publishers["oomwoo/health/stack"].messages
+        self.assertEqual(len(node.publishers["oomwoo/health/mcu_heartbeat"].messages), 1)
+        self.assertEqual(json.loads(stack_messages[-1].data)["state"], "fault")
+        self.assertEqual(json.loads(stack_messages[-1].data)["stale_critical"], ["nav2_controller"])
+
+    def test_invalid_roster_is_warned_and_ignored(self):
+        from oomwoo_health_monitor.health_monitor_node import HealthMonitorNode
+
+        node = HealthMonitorNode()
+        node._roster_cb(_String(data="{not json"))
+
+        self.assertEqual(len(node.logger.warnings), 1)
+        node._timer_cb()
+        stack = json.loads(node.publishers["oomwoo/health/stack"].messages[-1].data)
+        self.assertEqual(stack["state"], "no_roster")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contributions/health-monitor/xbattlax/tests/test_oomwoo_health_monitor.py
+++ b/contributions/health-monitor/xbattlax/tests/test_oomwoo_health_monitor.py
@@ -1,0 +1,122 @@
+import unittest
+
+from pathlib import Path
+import sys
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from oomwoo_health_monitor import (  # noqa: E402
+    ComponentHeartbeat,
+    ComponentSpec,
+    HealthAggregator,
+    HealthRoster,
+)
+
+
+class HealthAggregatorTest(unittest.TestCase):
+    def _roster(self):
+        return HealthRoster.from_components(
+            "dock_cycle",
+            (
+                ComponentSpec("recovery_safety", critical=True, max_age_sec=0.5),
+                ComponentSpec("dock_cycle", critical=True, max_age_sec=0.5),
+                ComponentSpec("logger", critical=False, max_age_sec=0.5),
+            ),
+        )
+
+    def _make_armed(self):
+        aggregator = HealthAggregator(arm_window_sec=0.2)
+        aggregator.update_roster(self._roster())
+        aggregator.update_heartbeat(ComponentHeartbeat("recovery_safety", "ok", 1.0))
+        aggregator.update_heartbeat(ComponentHeartbeat("dock_cycle", "ok", 1.0))
+        aggregator.update_heartbeat(ComponentHeartbeat("logger", "ok", 1.0))
+        aggregator.evaluate(1.0)
+        return aggregator
+
+    def test_no_roster_withholds_mcu_heartbeat(self):
+        result = HealthAggregator().evaluate(0.0)
+
+        self.assertEqual(result.state, "no_roster")
+        self.assertFalse(result.emit_mcu_heartbeat)
+
+    def test_missing_critical_component_faults(self):
+        aggregator = HealthAggregator()
+        aggregator.update_roster(self._roster())
+        aggregator.update_heartbeat(ComponentHeartbeat("recovery_safety", "ok", 1.0))
+
+        result = aggregator.evaluate(1.0)
+
+        self.assertEqual(result.state, "fault")
+        self.assertEqual(result.missing_critical, ("dock_cycle",))
+        self.assertFalse(result.emit_mcu_heartbeat)
+
+    def test_full_roster_arms_before_emitting_mcu_heartbeat(self):
+        aggregator = self._make_armed()
+
+        arming = aggregator.evaluate(1.1)
+        healthy = aggregator.evaluate(1.25)
+
+        self.assertEqual(arming.state, "arming")
+        self.assertFalse(arming.emit_mcu_heartbeat)
+        self.assertEqual(healthy.state, "healthy")
+        self.assertTrue(healthy.emit_mcu_heartbeat)
+
+    def test_stale_critical_component_stops_mcu_heartbeat(self):
+        aggregator = self._make_armed()
+        aggregator.evaluate(1.25)
+
+        result = aggregator.evaluate(1.7)
+
+        self.assertEqual(result.state, "fault")
+        self.assertEqual(result.stale_critical, ("dock_cycle", "recovery_safety"))
+        self.assertFalse(result.emit_mcu_heartbeat)
+
+    def test_unhealthy_critical_component_faults(self):
+        aggregator = HealthAggregator(arm_window_sec=0.0)
+        aggregator.update_roster(self._roster())
+        aggregator.update_heartbeat(ComponentHeartbeat("recovery_safety", "error", 2.0))
+        aggregator.update_heartbeat(ComponentHeartbeat("dock_cycle", "ok", 2.0))
+
+        result = aggregator.evaluate(2.0)
+
+        self.assertEqual(result.state, "fault")
+        self.assertEqual(result.unhealthy_critical, ("recovery_safety",))
+        self.assertFalse(result.emit_mcu_heartbeat)
+
+    def test_advisory_fault_does_not_block_mcu_heartbeat(self):
+        aggregator = HealthAggregator(arm_window_sec=0.0)
+        aggregator.update_roster(self._roster())
+        aggregator.update_heartbeat(ComponentHeartbeat("recovery_safety", "ok", 3.0))
+        aggregator.update_heartbeat(ComponentHeartbeat("dock_cycle", "ok", 3.0))
+
+        result = aggregator.evaluate(3.0)
+
+        self.assertEqual(result.state, "healthy_with_advisory_faults")
+        self.assertEqual(result.advisory_faults, ("logger",))
+        self.assertTrue(result.emit_mcu_heartbeat)
+
+    def test_roster_change_disarms_until_new_critical_is_healthy(self):
+        aggregator = self._make_armed()
+        self.assertTrue(aggregator.evaluate(1.25).emit_mcu_heartbeat)
+        aggregator.update_roster(
+            HealthRoster.from_components(
+                "dock_cycle",
+                (
+                    ComponentSpec("recovery_safety", critical=True, max_age_sec=0.5),
+                    ComponentSpec("dock_cycle", critical=True, max_age_sec=0.5),
+                    ComponentSpec("localization", critical=True, max_age_sec=0.5),
+                ),
+            )
+        )
+
+        result = aggregator.evaluate(1.3)
+
+        self.assertEqual(result.state, "fault")
+        self.assertEqual(result.missing_critical, ("localization",))
+        self.assertFalse(result.emit_mcu_heartbeat)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contributions/health-monitor/xbattlax/tests/test_oomwoo_health_monitor.py
+++ b/contributions/health-monitor/xbattlax/tests/test_oomwoo_health_monitor.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import sys
 
 
-TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
-sys.path.insert(0, str(TOOLS_DIR))
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "oomwoo_health_monitor"
+sys.path.insert(0, str(PACKAGE_ROOT))
 
-from oomwoo_health_monitor import (  # noqa: E402
+from oomwoo_health_monitor.core import (  # noqa: E402
     ComponentHeartbeat,
     ComponentSpec,
     HealthAggregator,

--- a/contributions/health-monitor/xbattlax/tools/oomwoo_health_monitor.py
+++ b/contributions/health-monitor/xbattlax/tools/oomwoo_health_monitor.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+from typing import Iterable
+
+
+HEALTHY_LEVELS = {"ok", "healthy"}
+
+
+@dataclass(frozen=True)
+class ComponentSpec:
+    component_id: str
+    critical: bool = True
+    max_age_sec: float = 0.5
+
+    def __post_init__(self):
+        if not self.component_id:
+            raise ValueError("component_id is required")
+        if self.max_age_sec <= 0.0:
+            raise ValueError("max_age_sec must be positive")
+
+
+@dataclass(frozen=True)
+class HealthRoster:
+    task_id: str
+    components: tuple[ComponentSpec, ...]
+
+    def __post_init__(self):
+        if not self.task_id:
+            raise ValueError("task_id is required")
+        ids = [component.component_id for component in self.components]
+        if len(ids) != len(set(ids)):
+            raise ValueError("component ids must be unique")
+
+    @classmethod
+    def from_components(
+        cls,
+        task_id: str,
+        components: Iterable[ComponentSpec],
+    ) -> "HealthRoster":
+        return cls(task_id, tuple(components))
+
+    @property
+    def by_id(self) -> dict[str, ComponentSpec]:
+        return {component.component_id: component for component in self.components}
+
+
+@dataclass(frozen=True)
+class ComponentHeartbeat:
+    component_id: str
+    health: str
+    stamp_sec: float
+    detail: str = ""
+    sequence: int | None = None
+
+    @property
+    def is_well(self) -> bool:
+        return self.health.strip().lower() in HEALTHY_LEVELS
+
+
+@dataclass(frozen=True)
+class StackHealth:
+    state: str
+    task_id: str | None
+    emit_mcu_heartbeat: bool
+    missing_critical: tuple[str, ...] = ()
+    stale_critical: tuple[str, ...] = ()
+    unhealthy_critical: tuple[str, ...] = ()
+    advisory_faults: tuple[str, ...] = ()
+    healthy_for_sec: float = 0.0
+    source: str = "oomwoo_health_monitor"
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+
+class HealthAggregator:
+    def __init__(self, *, arm_window_sec: float = 0.25):
+        if arm_window_sec < 0.0:
+            raise ValueError("arm_window_sec must be non-negative")
+        self._arm_window_sec = arm_window_sec
+        self._roster: HealthRoster | None = None
+        self._heartbeats: dict[str, ComponentHeartbeat] = {}
+        self._healthy_since_sec: float | None = None
+
+    @property
+    def roster(self) -> HealthRoster | None:
+        return self._roster
+
+    def update_roster(self, roster: HealthRoster):
+        old_task = self._roster.task_id if self._roster else None
+        old_ids = set(self._roster.by_id) if self._roster else set()
+        new_ids = set(roster.by_id)
+        self._roster = roster
+        self._heartbeats = {
+            component_id: heartbeat
+            for component_id, heartbeat in self._heartbeats.items()
+            if component_id in new_ids
+        }
+        if old_task != roster.task_id or old_ids != new_ids:
+            self._healthy_since_sec = None
+
+    def update_heartbeat(self, heartbeat: ComponentHeartbeat):
+        self._heartbeats[heartbeat.component_id] = heartbeat
+
+    def evaluate(self, now_sec: float) -> StackHealth:
+        if self._roster is None:
+            self._healthy_since_sec = None
+            return StackHealth(
+                state="no_roster",
+                task_id=None,
+                emit_mcu_heartbeat=False,
+            )
+
+        missing: list[str] = []
+        stale: list[str] = []
+        unhealthy: list[str] = []
+        advisory_faults: list[str] = []
+
+        for component_id, spec in self._roster.by_id.items():
+            heartbeat = self._heartbeats.get(component_id)
+            if heartbeat is None:
+                if spec.critical:
+                    missing.append(component_id)
+                else:
+                    advisory_faults.append(component_id)
+                continue
+
+            age_sec = now_sec - heartbeat.stamp_sec
+            if age_sec < 0.0 or age_sec > spec.max_age_sec:
+                if spec.critical:
+                    stale.append(component_id)
+                else:
+                    advisory_faults.append(component_id)
+                continue
+
+            if not heartbeat.is_well:
+                if spec.critical:
+                    unhealthy.append(component_id)
+                else:
+                    advisory_faults.append(component_id)
+
+        if missing or stale or unhealthy:
+            self._healthy_since_sec = None
+            return StackHealth(
+                state="fault",
+                task_id=self._roster.task_id,
+                emit_mcu_heartbeat=False,
+                missing_critical=tuple(sorted(missing)),
+                stale_critical=tuple(sorted(stale)),
+                unhealthy_critical=tuple(sorted(unhealthy)),
+                advisory_faults=tuple(sorted(advisory_faults)),
+            )
+
+        if self._healthy_since_sec is None:
+            self._healthy_since_sec = now_sec
+
+        healthy_for_sec = now_sec - self._healthy_since_sec
+        if healthy_for_sec < self._arm_window_sec:
+            return StackHealth(
+                state="arming",
+                task_id=self._roster.task_id,
+                emit_mcu_heartbeat=False,
+                advisory_faults=tuple(sorted(advisory_faults)),
+                healthy_for_sec=healthy_for_sec,
+            )
+
+        return StackHealth(
+            state="healthy" if not advisory_faults else "healthy_with_advisory_faults",
+            task_id=self._roster.task_id,
+            emit_mcu_heartbeat=True,
+            advisory_faults=tuple(sorted(advisory_faults)),
+            healthy_for_sec=healthy_for_sec,
+        )

--- a/contributions/health-monitor/xbattlax/tools/sim_health_monitor.py
+++ b/contributions/health-monitor/xbattlax/tools/sim_health_monitor.py
@@ -6,9 +6,9 @@ import sys
 
 
 if __package__ in (None, ""):
-    sys.path.append(str(Path(__file__).resolve().parent))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "oomwoo_health_monitor"))
 
-from oomwoo_health_monitor import (  # noqa: E402
+from oomwoo_health_monitor.core import (  # noqa: E402
     ComponentHeartbeat,
     ComponentSpec,
     HealthAggregator,

--- a/contributions/health-monitor/xbattlax/tools/sim_health_monitor.py
+++ b/contributions/health-monitor/xbattlax/tools/sim_health_monitor.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parent))
+
+from oomwoo_health_monitor import (  # noqa: E402
+    ComponentHeartbeat,
+    ComponentSpec,
+    HealthAggregator,
+    HealthRoster,
+)
+
+
+def main() -> int:
+    aggregator = HealthAggregator(arm_window_sec=0.25)
+    roster = HealthRoster.from_components(
+        "cleaning_job",
+        (
+            ComponentSpec("recovery_safety", critical=True, max_age_sec=0.30),
+            ComponentSpec("nav2_controller", critical=True, max_age_sec=0.30),
+            ComponentSpec("localization", critical=True, max_age_sec=0.50),
+            ComponentSpec("telemetry_logger", critical=False, max_age_sec=1.00),
+        ),
+    )
+
+    for now_sec, event in (
+        (0.00, "boot_no_roster"),
+        (0.05, "roster_published"),
+        (0.10, "recovery_healthy"),
+        (0.15, "nav2_healthy"),
+        (0.20, "localization_healthy"),
+        (0.30, "advisory_healthy"),
+        (0.50, "armed"),
+        (0.90, "nav2_stale"),
+        (1.00, "nav2_recovers"),
+        (1.36, "advisory_stale_only"),
+    ):
+        if event == "roster_published":
+            aggregator.update_roster(roster)
+        elif event == "recovery_healthy":
+            aggregator.update_heartbeat(ComponentHeartbeat("recovery_safety", "ok", now_sec))
+        elif event == "nav2_healthy":
+            aggregator.update_heartbeat(ComponentHeartbeat("nav2_controller", "ok", now_sec))
+        elif event == "localization_healthy":
+            aggregator.update_heartbeat(ComponentHeartbeat("localization", "ok", now_sec))
+        elif event == "advisory_healthy":
+            aggregator.update_heartbeat(ComponentHeartbeat("telemetry_logger", "ok", now_sec))
+        elif event == "armed":
+            for component_id in ("recovery_safety", "nav2_controller", "localization"):
+                aggregator.update_heartbeat(ComponentHeartbeat(component_id, "ok", now_sec))
+        elif event == "nav2_recovers":
+            aggregator.update_heartbeat(ComponentHeartbeat("nav2_controller", "ok", now_sec))
+            aggregator.update_heartbeat(ComponentHeartbeat("recovery_safety", "ok", now_sec))
+            aggregator.update_heartbeat(ComponentHeartbeat("localization", "ok", now_sec))
+        elif event == "advisory_stale_only":
+            for component_id in ("recovery_safety", "nav2_controller", "localization"):
+                aggregator.update_heartbeat(ComponentHeartbeat(component_id, "ok", now_sec))
+
+        result = aggregator.evaluate(now_sec)
+        print(result.to_json())
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/SOFTWARE_INTERFACES.md
+++ b/docs/SOFTWARE_INTERFACES.md
@@ -160,6 +160,31 @@ Hard safety events must be handled by the MCU even if ROS2 is down. ROS2 can
 request motion, report state, and run recovery behaviors, but stale CPU
 heartbeats or unsafe sensor states must stop motion at the MCU layer.
 
+## Stack Health Monitor Draft
+
+The software stack should expose one aggregate health/deadman path to the MCU
+instead of relying on independent stale-command behavior for every topic.
+
+Initial simulation-first topics can use JSON over `std_msgs/msg/String` until an
+OOMWOO message package exists:
+
+| ROS2 interface | Producer | Consumer | Purpose |
+|---|---|---|---|
+| `/oomwoo/health/roster` | Task launch / job manager | Health monitor | Latched expected-component roster for the active task; marks components critical or advisory. |
+| `/oomwoo/health/component` | Safety-critical nodes | Health monitor | Work-path heartbeat with component id, health level, stamp, and optional detail. |
+| `/oomwoo/health/stack` | Health monitor | Diagnostics / app layer | Aggregated state: no roster, arming, healthy, healthy with advisory faults, or fault. |
+| `/oomwoo/health/mcu_heartbeat` | Health monitor / bridge | MCU bridge | Single stack-health heartbeat forwarded to the MCU only while all expected critical components are fresh and well. |
+
+Fail-safe behavior:
+
+- no roster means no MCU heartbeat
+- a missing, stale, or unhealthy critical component stops the MCU heartbeat
+- advisory component faults are reported but do not stop the robot
+- the monitor has an arming window and withholds the MCU heartbeat until the full
+  critical roster is confirmed healthy
+- component heartbeats must be emitted from useful work paths, not from
+  independent timers that can keep running while the component is wedged
+
 ## Validation Checklist
 
 A module submission that depends on the MVP simulation should document how to


### PR DESCRIPTION
## Summary

Follow-up to the maintainer comment on #33 about generalizing `/cmd_vel` holding into component health monitoring.

This PR adds a namespaced `health-monitor/xbattlax` stack-health monitor contribution and records the public draft contract in `docs/SOFTWARE_INTERFACES.md`.

What it includes:

- dependency-free stack-health aggregator core, now shared by the ROS2 package and simulator
- ROS2 `oomwoo_health_monitor` package with `health_monitor_node` and launch file
- JSON-over-`std_msgs/msg/String` adapter for `/oomwoo/health/roster` and `/oomwoo/health/component`
- `/oomwoo/health/stack` publication on each monitor tick
- `/oomwoo/health/mcu_heartbeat` publication only while the aggregate state is healthy
- roster contract for critical vs. advisory components
- freshness and health-level checks for component heartbeats
- fail-safe arming window before MCU heartbeat emission
- immediate heartbeat withholding on missing, stale, or unhealthy critical components
- advisory-fault reporting without stopping the robot
- deterministic JSONL simulator for boot, arming, stale critical node, recovery, and advisory-only faults
- unit tests for core deadman behavior and ROS2 node adapter behavior using lightweight stubs
- docs for the stack watchdog contract and recovery-safety integration

## Review Context

This keeps `/cmd_vel` holding as a motion-quality fix, but moves the robot-wide safety question to a general stack-health deadman: components publish work-path heartbeats, a health monitor checks the active roster, and only then is one MCU-facing stack heartbeat emitted.

## Verification

- `python3 -m unittest discover -s contributions/health-monitor/xbattlax/tests -p 'test_*.py'`
- `python3 contributions/health-monitor/xbattlax/tools/sim_health_monitor.py`
- `python3 -m py_compile contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/core.py contributions/health-monitor/xbattlax/oomwoo_health_monitor/oomwoo_health_monitor/health_monitor_node.py contributions/health-monitor/xbattlax/tools/sim_health_monitor.py`
- `git diff --check`
