### PR TITLE
Claim clean-and-map module (Pointer to self-hosted repo)

### DIFF
--- a/contributions/clean-and-map/Arkz-Deepak/README.md
+++ b/contributions/clean-and-map/Arkz-Deepak/README.md
@@ -1,0 +1,19 @@
+# Clean-and-Map Implementation by @Arkz-Deepak
+
+This is a pointer to my self-hosted implementation of the `clean-and-map` module. 
+
+**Repository Link:** [https://github.com/Arkz-Deepak/oomwoo-clean-and-map-arkz](https://github.com/Arkz-Deepak/oomwoo-clean-and-map-arkz)
+
+## Approach
+Following the maintainer's recommendation, I am breaking this down into phases. I am starting with a "clean-only" MVP using a pre-existing map to ensure the coverage path planning (CPP) logic scores well on the regression tests before introducing simultaneous SLAM.
+
+## Progress Update
+- [x] Initial self-hosted repository created.
+- [x] Pointer PR submitted to OOMWOO main repository.
+- [ ] Establish basic coverage path planning (CPP) node on a known map.
+- [ ] Pass the `coverage_regression.launch.py` harness.
+- [ ] Integrate simultaneous mapping (SLAM).
+- [ ] Handle bumper edge cases and LiDAR-invisible obstacles.
+
+## Instructions
+*Installation and run instructions will be updated here and in the self-hosted repo once the baseline ROS 2 node is functional.*


### PR DESCRIPTION
### Description
This PR claims the `clean-and-map` module and adds a pointer to my self-hosted implementation, per the maintainer's recommendation to start in a separate repository.

**Self-Hosted Repository:** https://github.com/Arkz-Deepak/oomwoo-clean-and-map-arkz

### Approach
As discussed in the repository discussions, I am breaking the development into phases. I will start with a "clean-only" MVP using a pre-existing map to ensure the coverage path planning (CPP) logic passes the `coverage_regression.launch.py` harness before integrating simultaneous SLAM.

I will update the progress in my self-hosted repo and link back here as milestones are reached.